### PR TITLE
Add Dutch documentation

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -15,10 +15,27 @@
       "to": "#3259A5"
     }
   },
+  "i18n": {
+    "defaultLocale": "en",
+    "locales": [
+      {
+        "locale": "en",
+        "name": "English"
+      },
+      {
+        "locale": "nl",
+        "name": "Nederlands"
+      }
+    ]
+  },
   "topbarLinks": [
     {
       "name": "Support",
       "url": "mailto:support@payrequest.io"
+    },
+    {
+      "name": "Nederlands",
+      "url": "/nl/introduction"
     }
   ],
   "topbarCtaButton": {
@@ -65,8 +82,43 @@
       "group": "Invoice Management",
       "pages": [
         "essentials/creating-invoices",
-        "essentials/sending-invoices", 
+        "essentials/sending-invoices",
         "essentials/tracking-payments"
+      ]
+    },
+    {
+      "group": "Aan de slag (NL)",
+      "pages": [
+        "nl/introduction",
+        "nl/quickstart",
+        "nl/development"
+      ]
+    },
+    {
+      "group": "Belangrijkste concepten (NL)",
+      "pages": [
+        "nl/essentials/payments",
+        "nl/essentials/payment-methods",
+        "nl/essentials/checkout-urls",
+        "nl/essentials/webhooks",
+        "nl/essentials/security"
+      ]
+    },
+    {
+      "group": "Zakelijke workflows (NL)",
+      "pages": [
+        "nl/essentials/invoice-templates",
+        "nl/essentials/customer-management",
+        "nl/essentials/payment-tracking",
+        "nl/essentials/reporting"
+      ]
+    },
+    {
+      "group": "Factuurbeheer (NL)",
+      "pages": [
+        "nl/essentials/creating-invoices",
+        "nl/essentials/sending-invoices",
+        "nl/essentials/tracking-payments"
       ]
     }
   ],

--- a/nl/development.mdx
+++ b/nl/development.mdx
@@ -1,0 +1,96 @@
+---
+title: 'Ontwikkeling'
+description: 'Leer hoe je wijzigingen lokaal kunt bekijken'
+---
+
+<Info>
+  **Voorwaarde** Je hebt Node.js (versie 18.10.0 of hoger) geïnstalleerd.
+</Info>
+
+Stap 1. Installeer Mintlify op je besturingssysteem:
+
+<CodeGroup>
+
+```bash npm
+npm i -g mintlify
+```
+
+```bash yarn
+yarn global add mintlify
+```
+
+</CodeGroup>
+
+Stap 2. Ga naar de map waar de documentatie staat (waar `mint.json` zich bevindt) en voer het volgende commando uit:
+
+```bash
+mintlify dev
+```
+
+De documentatiesite is nu beschikbaar op `http://localhost:3000`.
+
+### Aangepaste poorten
+
+Mintlify gebruikt standaard poort 3000. Gebruik de `--port`-vlag om een andere poort te kiezen. Bijvoorbeeld, met dit commando draait Mintlify op poort 3333:
+
+```bash
+mintlify dev --port 3333
+```
+
+Je krijgt een foutmelding zoals hieronder wanneer je Mintlify start op een poort die al in gebruik is:
+
+```md
+Error: listen EADDRINUSE: address already in use :::3000
+```
+
+## Mintlify-versies
+
+Elke CLI hoort bij een specifieke Mintlify-versie. Werk de CLI bij wanneer je lokale site er anders uitziet dan de productieomgeving.
+
+<CodeGroup>
+
+```bash npm
+npm i -g mintlify@latest
+```
+
+```bash yarn
+yarn global upgrade mintlify
+```
+
+</CodeGroup>
+
+## Deployen
+
+<Tip>
+  Onbeperkt aantal editors beschikbaar met het [Startup-abonnement](https://mintlify.com/pricing)
+</Tip>
+
+Na een succesvolle deploy zie je het volgende scherm:
+
+<Frame>
+  <img src="/images/checks-passed.png" style={{ borderRadius: '0.5rem' }} />
+</Frame>
+
+## Probleemoplossing
+
+Zo los je veelvoorkomende problemen met de CLI op.
+
+<AccordionGroup>
+  <Accordion title="Mintlify laadt niet">
+    Update naar Node v18. Voer `mintlify install` uit en probeer het opnieuw.
+  </Accordion>
+  <Accordion title="No such file or directory op Windows">
+Ga naar de map `C:/Users/Username/.mintlify/` en verwijder de map `mint`.
+Open vervolgens Git Bash op deze locatie en voer `git clone
+https://github.com/mintlify/mint.git` uit.
+
+Herhaal stap 3.
+
+  </Accordion>
+  <Accordion title="Onbekende fout">
+    Navigeer naar de root van je apparaat en verwijder de map ~/.mintlify.
+    Voer daarna opnieuw `mintlify dev` uit.
+  </Accordion>
+</AccordionGroup>
+
+Benieuwd wat er veranderd is in een CLI-versie? [Bekijk de CLI-changelog.](/changelog/command-line)

--- a/nl/essentials/checkout-urls.mdx
+++ b/nl/essentials/checkout-urls.mdx
@@ -1,0 +1,418 @@
+---
+title: 'Vooraf ingevulde checkout-URL\'s'
+description: 'Stuur klanten directe links naar de checkout met vooraf ingevulde producten en gegevens'
+---
+
+# Vooraf ingevulde checkout-URL's
+
+Stuur klanten directe links om producten te kopen terwijl hun gegevens al zijn ingevuld. Vooraf ingevulde checkout-URL's besparen je klanten tijd en verhogen de conversie doordat alle frictie uit het koopproces verdwijnt.
+
+## Hoe het werkt
+
+In plaats van klanten naar je shop te sturen waar ze producten moeten zoeken en toevoegen aan de winkelwagen, maak je directe checkout-links die:
+
+- Bepaalde producten vooraf aan de winkelwagen toevoegen
+- Naam, e-mail en adresgegevens vooraf invullen
+- Trackinginformatie of speciale vereisten meesturen
+- Klanten direct naar de betaalstap brengen
+
+<CardGroup cols={2}>
+  <Card title="Sneller afrekenen" icon="bolt">
+    Klanten slaan het browsen over en gaan meteen naar betalen
+  </Card>
+  <Card title="Hogere conversie" icon="chart-line">
+    Minder frictie leidt tot meer succesvolle aankopen
+  </Card>
+  <Card title="Betere ervaring" icon="heart">
+    Klanten hoeven bekende gegevens niet opnieuw in te vullen
+  </Card>
+  <Card title="Eenvoudig traceren" icon="tag">
+    Voeg campagnecodes en referral-informatie toe
+  </Card>
+</CardGroup>
+
+## Basisopbouw van de URL
+
+Vooraf ingevulde checkout-URL's volgen dit formaat:
+
+```
+https://jouwshop.com/checkout?parameter=waarde&parameter2=waarde2
+```
+
+Of wanneer je het hoofd PayRequest-domein gebruikt:
+```
+https://payrequest.app/shop/jouwshopnaam/checkout?parameter=waarde&parameter2=waarde2
+```
+
+<Info>
+Vervang `jouwshop.com` door je eigen domein en `jouwshopnaam` door de naam van je shop in PayRequest.
+</Info>
+
+## Klantinformatie-parameters
+
+Vul de klantgegevens vooraf in om tijd te besparen:
+
+| Parameter | Beschrijving | Voorbeeld |
+|-----------|--------------|-----------|
+| `name` | Volledige naam van de klant | `name=Jan%20Jansen` |
+| `email` | E-mailadres van de klant | `email=jan@example.com` |
+| `address` | Straatadres van de klant | `address=Hoofdstraat%20123` |
+| `city` | Woonplaats van de klant | `city=Amsterdam` |
+| `postal` | Postcode | `postal=1234AB` |
+| `country` | Land (2-letterige code) | `country=NL` |
+
+<Warning>
+Vergeet niet speciale tekens zoals spaties (`%20`) en symbolen te URL-encoderen.
+</Warning>
+
+### Vergrendel vooraf ingevulde klantgegevens
+
+Wil je voorkomen dat klanten de ingevulde gegevens aanpassen? Voeg dan de parameter `disabled=true` toe aan de checkout-URL. Wanneer deze vlag actief is:
+
+- Worden naam, e-mail, adres, woonplaats, postcode en land alleen-lezen.
+- Zien klanten een blauwe melding: "Klantgegevens zijn vooraf ingevuld en vergrendeld – je kunt met deze gegevens betalen."
+- Kunnen klanten de checkout alsnog afronden met de vooraf ingevulde informatie.
+
+Verwijder de parameter (of zet op `disabled=false`) als klanten hun gegevens weer mogen wijzigen. Dit gedrag komt overeen met de `disabled`-parameter op dynamische productlinks en zorgt voor een consistente ervaring op het platform.
+
+## Productparameters
+
+Voeg specifieke producten toe aan de winkelwagen van de klant:
+
+| Parameter | Beschrijving | Voorbeeld |
+|-----------|--------------|-----------|
+| `product` | Product-ID dat moet worden toegevoegd | `product=123` |
+| `quantity` | Aantal van het product | `quantity=2` |
+
+Bekijk de productdetails in je PayRequest-dashboard om de product-ID te vinden. De ID staat in de URL of in de productinstellingen.
+
+## Aangepaste velden
+
+Met aangepaste velden verzamel je extra informatie of voeg je trackingdata toe. PayRequest ondersteunt drie formats:
+
+<Tabs>
+  <Tab title="Standaardformaat">
+    Gebruik het voorvoegsel `customfield_` voor zichtbare velden die klanten zien:
+
+    ```
+    customfield_size=Large
+    customfield_color=Red
+    customfield_notes=Speciale%20wensen
+    ```
+
+    Deze velden verschijnen op het checkoutformulier en klanten kunnen ze aanpassen indien nodig.
+  </Tab>
+
+  <Tab title="Productspecifiek">
+    Gebruik het voorvoegsel `product_customfield_` voor tracking en intern gebruik:
+
+    ```
+    product_customfield_productcode=SKU001
+    product_customfield_campaign=summer2024
+    product_customfield_referrer=partner123
+    ```
+
+    Deze velden zijn meestal verborgen voor klanten en bedoeld voor zakelijke analyse.
+  </Tab>
+
+  <Tab title="Kort formaat">
+    Gebruik het voorvoegsel `cf_` als compacte variant:
+
+    ```
+    cf_servers=2
+    cf_domain=example.com
+    cf_priority=high
+    ```
+
+    Handig als je korte parameters wilt gebruiken.
+  </Tab>
+</Tabs>
+
+## Praktische voorbeelden
+
+### 1. Simpele productlink
+Stuur een klant rechtstreeks naar een specifiek product:
+
+```
+https://jouwshop.com/checkout?product=123&quantity=1&name=Sara%20de%20Vries&email=sara@example.com
+```
+
+Deze link voegt product #123 toe aan de winkelwagen en vult naam en e-mail in.
+
+### 2. Volledige klantgegevens
+Neem alle klantinformatie mee voor een razendsnelle checkout:
+
+```
+https://jouwshop.com/checkout?product=456&name=Jan%20Jansen&email=jan@example.com&address=Hoofdstraat%20123&city=Amsterdam&postal=1234AB&country=NL
+```
+
+### 3. Met productopties
+Voeg productvariaties of opties toe:
+
+```
+https://jouwshop.com/checkout?product=789&quantity=2&customfield_size=Large&customfield_color=Blue&name=Klant%20Naam&email=klant@example.com
+```
+
+### 4. Campagnetracking
+Volg waar klanten vandaan komen:
+
+```
+https://jouwshop.com/checkout?product=101&product_customfield_campaign=email_nieuwsbrief&product_customfield_source=mailchimp&name=Nieuwsbrief%20abonnee&email=abonnee@example.com
+```
+
+### 5. Offerte-opvolging
+Stuur klanten na een offerte een directe betaal-link:
+
+```
+https://jouwshop.com/checkout?product=555&quantity=5&customfield_quote_id=Q12345&product_customfield_sales_rep=john&name=Bedrijfseigenaar&email=eigenaar@bedrijf.com
+```
+
+### 6. Vergrendelde klantgegevens
+Deel een link met vooraf ingevulde gegevens die klanten niet kunnen wijzigen:
+
+```
+https://payrequest.me/shop/hostingwalk/checkout?product=4&name=Jan%20Jansen&email=jan@example.com&address=Hoofdstraat%20123&city=Amsterdam&postal=1234AB&country=NL&disabled=true
+```
+
+Hiermee blijven de klantgegevens vaststaan terwijl het betaalproces toch kan worden voltooid.
+
+## Veelvoorkomende scenario's
+
+<AccordionGroup>
+  <Accordion title="E-mailcampagnes" icon="envelope">
+    Voeg checkoutlinks toe aan je e-mailcampagnes:
+
+    ```
+    https://jouwshop.com/checkout?product=123&product_customfield_campaign=feestdagen2024&name={{customer_name}}&email={{customer_email}}
+    ```
+
+    Gebruik de merge tags van je e-mailplatform om elke link te personaliseren.
+  </Accordion>
+
+  <Accordion title="Sales follow-up" icon="handshake">
+    Stuur na een salesgesprek een directe aankooppagina:
+
+    ```
+    https://jouwshop.com/checkout?product=456&customfield_package=premium&product_customfield_sales_rep=sarah&name=Prospect%20Naam
+    ```
+  </Accordion>
+
+  <Accordion title="Upsells via support" icon="headset">
+    Link vanuit supporttickets naar extra diensten:
+
+    ```
+    https://jouwshop.com/checkout?product=789&product_customfield_ticket_id=T456&customfield_priority=urgent
+    ```
+  </Accordion>
+
+  <Accordion title="Partner-/affiliatelinks" icon="users">
+    Houd verkopen vanuit partners bij:
+
+    ```
+    https://jouwshop.com/checkout?product=101&product_customfield_partner=tech_solutions&product_customfield_commission=10percent
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Handleiding URL-encoding
+
+Encodeer altijd speciale tekens in URL-parameters:
+
+<CardGroup cols={2}>
+  <Card title="Veelgebruikte tekens" icon="code">
+    - **Spatie**: `%20` of `+`
+    - **@**: `%40`
+    - **&**: `%26`
+    - **=**: `%3D`
+    - **#**: `%23`
+  </Card>
+  <Card title="Voorbeelden" icon="link">
+    - `Jan Jansen` → `Jan%20Jansen`
+    - `gebruiker@email.com` → `gebruiker%40email.com`
+    - `Speciaal & teken` → `Speciaal%20%26%20teken`
+  </Card>
+</CardGroup>
+
+<Tip>
+De meeste programmeertalen hebben ingebouwde functies voor URL-encoding. Gebruik in JavaScript `encodeURIComponent()`. In PHP gebruik je `urlencode()`.
+</Tip>
+
+## Validatie en foutafhandeling
+
+PayRequest valideert alle URL-parameters voor een soepele checkout-ervaring:
+
+### Wat wordt gevalideerd
+
+<Tabs>
+  <Tab title="Productvalidatie">
+    - Product moet bestaan in je shop
+    - Product moet actief en beschikbaar zijn
+    - Aantal moet een positief getal zijn
+  </Tab>
+
+  <Tab title="Klantdata">
+    - E-mailadressen moeten een geldig formaat hebben
+    - Landcodes moeten geldige 2-letterige codes zijn
+    - Postcodes worden gevalideerd per land
+  </Tab>
+
+  <Tab title="Aangepaste velden">
+    - Velden moeten overeenkomen met je productconfiguratie
+    - Nummer-velden moeten een geldig nummer bevatten
+    - URL-velden moeten geldige URL's zijn
+  </Tab>
+</Tabs>
+
+### Gedrag bij fouten
+
+Als er problemen zijn met de URL-parameters:
+
+- **Ongeldige producten**: Worden genegeerd, checkout gaat door zonder deze items
+- **Ongeldige customfields**: Worden weggefilterd, geldige velden blijven staan
+- **Onjuist opgebouwde URL's**: Vallen netjes terug naar de normale checkout
+
+<Note>
+Alle validatiefouten worden voor jou gelogd, maar klanten zien een nette checkout zonder foutmeldingen.
+</Note>
+
+## Veiligheid en best practices
+
+<Warning>
+**Plaats nooit gevoelige informatie** zoals wachtwoorden, creditcardnummers of privédetails in checkout-URL's. URL's kunnen worden gelogd en gecachet door browsers en servers.
+</Warning>
+
+### Aanbevolen werkwijze
+
+<Steps>
+  <Step title="Gebruik HTTPS">
+    Maak altijd gebruik van beveiligde HTTPS-URL's voor checkout-links
+  </Step>
+  <Step title="Valideer op je backend">
+    Controleer de definitieve bestelling altijd in je eigen systemen
+  </Step>
+  <Step title="Monitor gebruik">
+    Analyseer checkout-URL's om conversies te optimaliseren
+  </Step>
+  <Step title="Houd URL's overzichtelijk">
+    Voeg alleen noodzakelijke parameters toe voor korte, duidelijke links
+  </Step>
+</Steps>
+
+### Beveiligingsfeatures
+
+- **Shopisolatie**: Producten worden alleen geaccepteerd als ze bij jouw shop horen
+- **Veldenvalidering**: Aangepaste velden moeten overeenkomen met de productinstellingen
+- **Audit logging**: Alle URL-parameters worden gelogd voor controle
+- **Sessiebescherming**: Bestaande sessies van klanten blijven behouden
+
+## Test je URL's
+
+<CodeGroup>
+```bash Test-URL
+# Vervang met je eigen domein en product-ID
+https://jouwshop.com/checkout?product=123&name=Test%20Klant&email=test@example.com
+```
+
+```javascript Genereer URL's in JavaScript
+function genereerCheckoutUrl(domein, productId, klantData, customFields = {}) {
+  const params = new URLSearchParams();
+
+  // Product toevoegen
+  params.append('product', productId);
+
+  // Klantgegevens toevoegen
+  if (klantData.name) params.append('name', klantData.name);
+  if (klantData.email) params.append('email', klantData.email);
+  if (klantData.address) params.append('address', klantData.address);
+
+  // Customfields toevoegen
+  Object.entries(customFields).forEach(([key, value]) => {
+    params.append(`customfield_${key}`, value);
+  });
+
+  return `https://${domein}/checkout?${params.toString()}`;
+}
+
+// Voorbeeld
+const url = genereerCheckoutUrl('jouwshop.com', 123, {
+  name: 'Jan Jansen',
+  email: 'jan@example.com'
+}, {
+  size: 'Large',
+  color: 'Blue'
+});
+```
+</CodeGroup>
+
+## Probleemoplossing
+
+<AccordionGroup>
+  <Accordion title="Product wordt niet toegevoegd" icon="shopping-cart">
+    **Mogelijke oorzaken:**
+    - Product-ID bestaat niet
+    - Product is inactief of niet beschikbaar
+    - Product hoort bij een andere shop
+
+    **Oplossing:** Controleer de product-ID in je PayRequest-dashboard
+  </Accordion>
+
+  <Accordion title="Klantgegevens worden niet ingevuld" icon="user">
+    **Mogelijke oorzaken:**
+    - Parameters zijn niet goed ge-URL-encodeerd
+    - Typefouten in parameternamen
+    - Speciale tekens zijn niet gecodeerd
+
+    **Oplossing:** Controleer de spelling en gebruik URL-encoding
+  </Accordion>
+
+  <Accordion title="Customfields verschijnen niet" icon="tags">
+    **Mogelijke oorzaken:**
+    - Customfield bestaat niet voor dit product
+    - Verkeerd voorvoegsel gebruikt
+    - Type van het veld klopt niet
+
+    **Oplossing:** Controleer de productinstellingen voor customfields
+  </Accordion>
+
+  <Accordion title="URL is te lang" icon="link">
+    **Mogelijke oorzaken:**
+    - Te veel parameters
+    - Zeer lange customfield-waarden
+    - Complexe productconfiguraties
+
+    **Oplossing:** Gebruik kortere veldnamen of splits het proces in meerdere stappen
+  </Accordion>
+</AccordionGroup>
+
+## Volgende stappen
+
+<CardGroup cols={2}>
+  <Card
+    title="Betaalmethoden"
+    icon="credit-card"
+    href="/nl/essentials/payment-methods"
+  >
+    Leer meer over betaalopties voor je klanten
+  </Card>
+  <Card
+    title="Klantenbeheer"
+    icon="users"
+    href="/nl/essentials/customer-management"
+  >
+    Organiseer en volg klantinformatie
+  </Card>
+  <Card
+    title="Webhooks"
+    icon="webhook"
+    href="/nl/essentials/webhooks"
+  >
+    Ontvang meldingen wanneer klanten afronden
+  </Card>
+  <Card
+    title="Betalingen bijhouden"
+    icon="chart-line"
+    href="/nl/essentials/payment-tracking"
+  >
+    Monitor je verkopen en betaalprestaties
+  </Card>
+</CardGroup>

--- a/nl/essentials/creating-invoices.mdx
+++ b/nl/essentials/creating-invoices.mdx
@@ -1,0 +1,204 @@
+---
+title: 'Facturen aanmaken'
+description: 'Leer hoe je professionele facturen maakt met PayRequest'
+---
+
+# Facturen aanmaken
+
+Met PayRequest stel je eenvoudig professionele, merkgebonden facturen op zodat je sneller betaald krijgt. Of je nu diensten, producten of uren factureert: onze factuurbouwer biedt alle functies die je nodig hebt.
+
+## Aan de slag met facturen
+
+<Steps>
+  <Step title="Open de factuurbouwer">
+    Ga in het dashboard naar **Facturen > Nieuwe factuur maken**.
+  </Step>
+  <Step title="Voeg klantgegevens toe">
+    Vul de klantgegevens in, zoals naam, e-mail en factuuradres.
+  </Step>
+  <Step title="Voeg factuurregels toe">
+    Beschrijf de producten of diensten met aantallen en prijzen.
+  </Step>
+  <Step title="Personaliseer en verzend">
+    Voeg je branding toe, stel betalingsvoorwaarden in en verstuur de factuur.
+  </Step>
+</Steps>
+
+## Functies van de factuurbouwer
+
+### Klantinformatie
+Beheer klantdetails eenvoudig:
+- **Klantendatabase**: Kies uit bestaande klanten of voeg nieuwe toe
+- **Factuuradres**: Complete adresgegevens opnemen
+- **Contactgegevens**: E-mail en telefoon voor communicatie
+- **Klantnotities**: Interne notities vastleggen
+
+### Factuurregels en prijzen
+Stel gedetailleerde facturen op met:
+
+<CardGroup cols={2}>
+  <Card title="Factuurregels" icon="list">
+    - Omschrijvingen van producten/diensten
+    - Aantallen en stuksprijzen
+    - Btw-tarieven en berekeningen
+    - Kortingen en correcties
+  </Card>
+  <Card title="Prijsopties" icon="dollar-sign">
+    - Ondersteuning voor meerdere valuta
+    - Automatische belastingberekeningen
+    - Percentage- of vaste kortingen
+    - Verzend- en administratiekosten
+  </Card>
+</CardGroup>
+
+### Branding en personalisatie
+
+Laat je facturen er professioneel uitzien:
+
+<Tabs>
+  <Tab title="Visuele branding">
+    - Upload je bedrijfslogo
+    - Kies jouw huisstijlkleuren
+    - Selecteer professionele sjablonen
+    - Pas header- en footer-teksten aan
+  </Tab>
+  <Tab title="Inhoud">
+    - Voeg aangepaste factuurnummers toe
+    - Neem betalingsvoorwaarden op
+    - Voeg notities en instructies toe
+    - Vermeld je bedrijfsregistratiegegevens
+  </Tab>
+</Tabs>
+
+## Factuursjablonen
+
+Bespaar tijd met herbruikbare sjablonen:
+
+### Sjablonen maken
+1. Stel een factuur op met standaarditems en prijzen
+2. Klik op **Opslaan als sjabloon** vóór het verzenden
+3. Geef de sjabloon een naam (bijv. "Maandelijkse consultancy", "Websiteontwerp")
+4. Stel standaardbetalingstermijnen en vervaldatums in
+
+### Sjablonen gebruiken
+- Kies een sjabloon bij het aanmaken van nieuwe facturen
+- Pas details per klant aan
+- Branding wordt automatisch meegenomen
+- Ideaal voor terugkerende diensten of pakketten
+
+## Betalingsvoorwaarden en vervaldatums
+
+Bepaal hoe en wanneer je betaald wilt worden:
+
+<AccordionGroup>
+  <Accordion title="Betalingsvoorwaarden" icon="calendar">
+    Stel duidelijke verwachtingen:
+    - Netto 15, 30 of 60 dagen
+    - Betaalbaar bij ontvangst
+    - Aangepaste betaalplannen
+    - Kortingen bij snelle betaling
+  </Accordion>
+  <Accordion title="Vervaldatumopties" icon="clock">
+    Kies wat het beste past:
+    - Vaste vervaldatums
+    - Aantal dagen na factuurdatum
+    - Einde-van-de-maand-voorwaarden
+    - Eigen berekeningen voor vervaldatums
+  </Accordion>
+</AccordionGroup>
+
+## Ondersteuning voor meerdere valuta
+
+Factureer klanten wereldwijd:
+- Ondersteuning voor meer dan 100 valuta
+- Automatische wisselkoersupdates
+- Klanten zien bedragen in hun lokale valuta
+- Jij ontvangt betalingen in je voorkeursvaluta
+
+## Factuurnummering
+
+Houd facturen overzichtelijk:
+
+<CardGroup cols={2}>
+  <Card title="Automatische nummering" icon="hashtag">
+    - Opeenvolgende factuurnummers
+    - Eigen voorvoegsels (INV-, 2024-)
+    - Automatische incremente
+    - Geen dubbele nummers
+  </Card>
+  <Card title="Aangepaste formaten" icon="edit">
+    - Jaar- en maandcodes toevoegen
+    - Klantspecifieke nummering
+    - Nummering per project
+    - Bestaande nummerreeksen importeren
+  </Card>
+</CardGroup>
+
+## Facturen versturen
+
+Meerdere manieren om facturen te bezorgen:
+
+### Verzend per e-mail
+- Professionele e-mailsjablonen
+- Automatische leveringsbevestiging
+- Voeg betaalinstructies toe
+- Voeg persoonlijke berichten toe
+
+### Direct delen
+- Genereer deelbare factuurlinks
+- Embed facturen op je website
+- Download PDF voor offline gebruik
+- Printklare opmaak
+
+## Best practices
+
+<Warning>
+  Controleer altijd het e-mailadres van de klant en de factuurbedragen voor verzending om betalingsvertragingen te voorkomen.
+</Warning>
+
+### Tips voor professionele facturen
+- Gebruik duidelijke omschrijvingen
+- Houd de toon professioneel
+- Stel redelijke betaalvoorwaarden
+- Voeg je contactgegevens toe
+- Vermeld beleid voor late betalingen
+
+### Sneller betaald krijgen
+- Verstuur facturen direct na oplevering
+- Bied meerdere betaalopties aan
+- Stel automatische herinneringen in
+- Bied korting bij snelle betaling
+- Gebruik heldere, eenvoudige taal
+
+## Volgende stappen
+
+<CardGroup cols={2}>
+  <Card
+    title="Facturen verzenden"
+    icon="paper-plane"
+    href="/nl/essentials/sending-invoices"
+  >
+    Leer hoe je facturen verstuurt en aflevert bij klanten
+  </Card>
+  <Card
+    title="Betalingen volgen"
+    icon="chart-line"
+    href="/nl/essentials/tracking-payments"
+  >
+    Volg factuurstatussen en betalingsvoortgang
+  </Card>
+  <Card
+    title="Klantenbeheer"
+    icon="users"
+    href="/nl/essentials/customer-management"
+  >
+    Organiseer en beheer je klantendatabase
+  </Card>
+  <Card
+    title="Factuursjablonen"
+    icon="template"
+    href="/nl/essentials/invoice-templates"
+  >
+    Maak en beheer herbruikbare factuursjablonen
+  </Card>
+</CardGroup>

--- a/nl/essentials/customer-management.mdx
+++ b/nl/essentials/customer-management.mdx
@@ -1,0 +1,258 @@
+---
+title: 'Klantenbeheer'
+description: 'Organiseer en beheer je klantrelaties'
+---
+
+# Klantenbeheer
+
+Bouw sterke klantrelaties op met de uitgebreide klantbeheerfuncties van PayRequest. Houd klantgegevens, betalingsgeschiedenis en communicatievoorkeuren bij om betere service te bieden en sneller betaald te krijgen.
+
+## Klantendatabase
+
+<CardGroup cols={2}>
+  <Card title="Klantprofielen" icon="user">
+    Sla volledige klantinformatie op, inclusief contactgegevens, factuuradres en betaalvoorkeuren
+  </Card>
+  <Card title="Betalingsgeschiedenis" icon="history">
+    Volg alle verstuurde facturen, betalingen en communicatie per klant
+  </Card>
+  <Card title="Aangepaste velden" icon="tags">
+    Voeg eigen velden toe voor branche- of bedrijfsspecifieke klantinformatie
+  </Card>
+  <Card title="Notities & communicatie" icon="message-circle">
+    Bewaar alle interacties en belangrijke notities per klant
+  </Card>
+</CardGroup>
+
+## Klanten toevoegen
+
+### Handmatig invoeren
+Voeg klanten individueel toe met volledige informatie:
+
+<Steps>
+  <Step title="Basisgegevens">
+    Vul naam, e-mailadres en telefoonnummer in
+  </Step>
+  <Step title="Factuurgegevens">
+    Voeg factuuradres en bedrijfsinformatie toe
+  </Step>
+  <Step title="Betaalvoorkeuren">
+    Stel favoriete betaalmethoden en voorwaarden in
+  </Step>
+  <Step title="Aangepaste informatie">
+    Voeg eigen velden toe die relevant zijn voor je bedrijf
+  </Step>
+</Steps>
+
+### Klanten importeren
+Importeer klanten in bulk vanuit bestaande systemen:
+
+- **CSV-upload**: Importeren vanuit spreadsheets of andere bronnen
+- **Integratiesync**: Koppel met CRM- of boekhoudsoftware
+- **API-import**: Programmeerbaar klanten toevoegen
+- **Datavalidatie**: Automatische controle van klantgegevens
+
+## Klantinformatie beheren
+
+### Contactgegevens
+Houd klantgegevens actueel:
+
+<AccordionGroup>
+  <Accordion title="Contactdetails" icon="address-book">
+    - Primaire en secundaire e-mailadressen
+    - Telefoonnummers (mobiel en zakelijk)
+    - Fysieke adressen en factuuradressen
+    - Noodcontactinformatie
+  </Accordion>
+  <Accordion title="Bedrijfsinformatie" icon="building">
+    - Bedrijfsnaam en registratiedetails
+    - Branche en bedrijfstype
+    - Omvang en omzet
+    - Btw- of belastingnummers
+  </Accordion>
+</AccordionGroup>
+
+### Communicatievoorkeuren
+Respecteer hoe klanten benaderd willen worden:
+
+- **Voorkeurskanaal**: E-mail, telefoon of sms
+- **Beste contactmomenten**: Kantooruren en tijdzones
+- **Communicatiefrequentie**: Hoe vaak herinneringen verstuurd worden
+- **Taalvoorkeuren**: Ondersteuning voor meerdere talen
+
+## Betalingsgeschiedenis bijhouden
+
+### Transactieoverzicht
+Volledige betalingshistorie per klant:
+
+<CardGroup cols={3}>
+  <Card title="Factuurhistorie" icon="file-text">
+    - Alle facturen die naar de klant zijn verstuurd
+    - Status en verzenddata van facturen
+    - Betaalde bedragen en betaalmethoden
+    - Openstaande saldi
+  </Card>
+  <Card title="Betaalpatronen" icon="chart-line">
+    - Gemiddelde betaaltermijnen
+    - Voorkeursbetaalmethoden
+    - Seizoensgebonden trends
+    - Betrouwbaarheidsscore
+  </Card>
+  <Card title="Communicatielog" icon="message-square">
+    - Alle e-mailcommunicatie
+    - Reacties en vragen van klanten
+    - Verstuurde herinneringen
+    - Geschiedenis van supporttickets
+  </Card>
+</CardGroup>
+
+## Klantsegmentatie
+
+### Automatische segmentatie
+PayRequest categoriseert klanten automatisch:
+
+<Tabs>
+  <Tab title="Betaalgedrag">
+    - **Snelle betalers**: Altijd binnen termijn
+    - **Betrouwbare betalers**: Meestal op tijd, soms lichte vertraging
+    - **Langzame betalers**: Betalen vaak te laat maar uiteindelijk wel
+    - **Probleemklanten**: Vereisen veel opvolging
+  </Tab>
+  <Tab title="Zakelijke waarde">
+    - **Hoge waarde**: Grote of frequente facturen
+    - **Reguliere klanten**: Consistente omzet
+    - **Incidentele klanten**: Sporadische facturen
+    - **Nieuwe klanten**: Recent toegevoegd
+  </Tab>
+</Tabs>
+
+### Eigen segmenten
+Maak je eigen klantcategorieën:
+
+- **Branchetypes**: Advocaten, aannemers, retailers, enz.
+- **Regio's**: Lokaal, nationaal, internationaal
+- **Diensttypes**: Verschillende diensten die je levert
+- **Klantgrootte**: Kleinbedrijf, enterprise, particulier
+
+## Klantcommunicatie
+
+### Automatische communicatie
+Stel geautomatiseerde klantcommunicatie in:
+
+<AccordionGroup>
+  <Accordion title="Welkomstberichten" icon="hand-wave">
+    - Onboarding-e-mails voor nieuwe klanten
+    - Instructies voor betaalinstellingen
+    - Introductie van je diensten
+    - Contactgegevens en supportinformatie
+  </Accordion>
+  <Accordion title="Betalingsherinneringen" icon="bell">
+    - Herinneringen vóór de vervaldatum
+    - Notificaties op de vervaldag
+    - Opvolging bij achterstallige betalingen
+    - Bedankberichten na betaling
+  </Accordion>
+</AccordionGroup>
+
+### Handmatige communicatie
+Geef belangrijke klanten extra aandacht:
+
+- **Directe berichten**: Verstuur gepersonaliseerde e-mails vanuit het platform
+- **Eigen sjablonen**: Creëer templates voor veelvoorkomende berichten
+- **Notities maken**: Leg telefoongesprekken en afspraken vast
+- **Opvolging plannen**: Stel herinneringen in voor contactmomenten
+
+## Klantenportaal
+
+### Selfservice-functionaliteit
+Geef klanten toegang tot hun eigen informatie:
+
+<CardGroup cols={2}>
+  <Card title="Factuurtoegang" icon="file-invoice">
+    - Bekijk huidige en eerdere facturen
+    - Download factuur-pdf's
+    - Controleer betalingsstatus
+    - Betaal online
+  </Card>
+  <Card title="Accountbeheer" icon="settings">
+    - Werk contactgegevens bij
+    - Beheer betaalmethoden
+    - Stel communicatievoorkeuren in
+    - Bekijk betalingshistorie
+  </Card>
+</CardGroup>
+
+## Klantanalyses
+
+### Prestatie-indicatoren
+Krijg inzicht in klantrelaties:
+
+<Tabs>
+  <Tab title="Betaalanalyse">
+    - Customer lifetime value
+    - Gemiddelde betalingstermijnen
+    - Voorkeursbetaalmethoden
+    - Succespercentages van incasso
+  </Tab>
+  <Tab title="Zakelijke analyse">
+    - Omzet per klant
+    - Klantacquisitiekosten
+    - Retentiecijfers
+    - Groeikansen
+  </Tab>
+</Tabs>
+
+## Databeheer
+
+### Gegevensbescherming
+Beveilig klantinformatie:
+
+<Warning>
+  Zorg dat je voldoet aan regelgeving zoals de GDPR bij het opslaan en verwerken van klantgegevens.
+</Warning>
+
+- **Encryptie**: Alle klantdata is versleuteld tijdens transport en in rust
+- **Toegangscontrole**: Beperk wie klantinformatie kan zien of wijzigen
+- **Bewaartermijnen**: Automatische naleving van retention policies
+- **Privacy-instellingen**: Respecteer voorkeuren van klanten
+
+### Gegevens exporteren
+Exporteer klantinformatie wanneer nodig:
+
+- **CSV-export**: Spreadsheetformaat voor analyses
+- **PDF-rapporten**: Professionele klantoverzichten
+- **Integratie-export**: Synchroniseer met CRM- of boekhoudsystemen
+- **Back-upopties**: Regelmatige back-ups van gegevens
+
+## Volgende stappen
+
+<CardGroup cols={2}>
+  <Card
+    title="Facturen maken"
+    icon="file-invoice"
+    href="/nl/essentials/creating-invoices"
+  >
+    Gebruik klantinformatie om snel facturen te maken
+  </Card>
+  <Card
+    title="Betalingen volgen"
+    icon="chart-line"
+    href="/nl/essentials/payment-tracking"
+  >
+    Monitor het betaalgedrag van klanten
+  </Card>
+  <Card
+    title="Rapportages"
+    icon="chart-bar"
+    href="/nl/essentials/reporting"
+  >
+    Maak klant- en betaalrapportages
+  </Card>
+  <Card
+    title="Factuursjablonen"
+    icon="template"
+    href="/nl/essentials/invoice-templates"
+  >
+    Maak sjablonen voor verschillende klanttypen
+  </Card>
+</CardGroup>

--- a/nl/essentials/invoice-templates.mdx
+++ b/nl/essentials/invoice-templates.mdx
@@ -1,0 +1,135 @@
+---
+title: 'Factuursjablonen'
+description: 'Maak en beheer herbruikbare factuursjablonen'
+---
+
+# Factuursjablonen
+
+Bespaar tijd en behoud consistentie door herbruikbare factuursjablonen aan te maken voor je meest gebruikte diensten en producten. Sjablonen helpen je snel professionele facturen te versturen terwijl je merkuitstraling behouden blijft.
+
+## Aan de slag met sjablonen
+
+<Steps>
+  <Step title="Maak je eerste sjabloon">
+    Begin met een ingevulde factuur en sla deze op als sjabloon
+  </Step>
+  <Step title="Pas sjablooninstellingen aan">
+    Stel standaardvoorwaarden, branding en lay-outvoorkeuren in
+  </Step>
+  <Step title="Gebruik sjablonen voor nieuwe facturen">
+    Kies een sjabloon bij het aanmaken van een factuur zodat gegevens automatisch worden ingevuld
+  </Step>
+  <Step title="Beheer en update">
+    Houd sjablonen actueel terwijl je diensten zich ontwikkelen
+  </Step>
+</Steps>
+
+## Soorten sjablonen
+
+<CardGroup cols={2}>
+  <Card title="Dienstensjablonen" icon="briefcase">
+    Voor consultancy, design, development en andere diensten
+  </Card>
+  <Card title="Productsjablonen" icon="box">
+    Voor fysieke of digitale producten met vaste prijzen
+  </Card>
+  <Card title="Terugkerende sjablonen" icon="refresh">
+    Voor abonnementsfacturen en periodieke diensten
+  </Card>
+  <Card title="Projectsjablonen" icon="project-diagram">
+    Voor projectfacturatie op basis van milestones
+  </Card>
+</CardGroup>
+
+## Sjablonen maken
+
+### Vanuit bestaande facturen
+De makkelijkste manier om sjablonen te creëren:
+
+1. Maak een complete factuur met alle details
+2. Klik op **Opslaan als sjabloon** vóór het verzenden
+3. Geef je sjabloon een duidelijke naam
+4. Stel standaardbetalingstermijnen en vervaldatums in
+5. Kies welke informatie vooraf moet worden ingevuld
+
+### Sjabloonbouwer
+Maak sjablonen vanaf nul:
+
+- **Sjabloonnaam**: Beschrijvende naam zodat je hem snel herkent
+- **Standaarditems**: Veelgebruikte regels met omschrijving en prijs
+- **Betaalvoorwaarden**: Standaard vervaldatums en betalingscondities
+- **Branding**: Logo, kleuren en aangepaste berichten
+- **Klantvelden**: Welke klantinformatie je wilt opnemen
+
+## Onderdelen van een sjabloon
+
+<Tabs>
+  <Tab title="Factuurregels">
+    - Beschrijvingen van producten/diensten
+    - Standaardaantallen en prijzen
+    - Belastinginstellingen en tarieven
+    - Kortingsopties
+    - Aangepaste velden
+  </Tab>
+  <Tab title="Voorwaarden">
+    - Betaaltermijnen
+    - Boetes bij te late betaling
+    - Restitutiebeleid
+    - Servicevoorwaarden
+    - Contactinformatie
+  </Tab>
+  <Tab title="Branding-elementen">
+    - Positie van het bedrijfslogo
+    - Kleurenpalet
+    - Lettertypekeuzes
+    - Inhoud van header en footer
+    - Aangepaste berichten
+  </Tab>
+</Tabs>
+
+## Sjablonen beheren
+
+### Sjabloonorganisatie
+Houd overzicht over je sjablonen:
+
+- **Categorieën**: Groepeer op diensttype of klantsegment
+- **Tags**: Voeg zoekbare tags toe voor snelle filtering
+- **Favorieten**: Markeer vaak gebruikte sjablonen
+- **Archiveren**: Verberg verouderde sjablonen zonder ze te verwijderen
+
+### Sjabloonsupdates
+Houd sjablonen actueel:
+
+<AccordionGroup>
+  <Accordion title="Prijsupdates" icon="dollar-sign">
+    - Prijzen in bulk aanpassen
+    - Percentageverhogingen doorvoeren
+    - Seizoensgebonden prijswijzigingen
+    - Valuta bijwerken
+  </Accordion>
+  <Accordion title="Inhoud wijzigen" icon="edit">
+    - Dienstenomschrijvingen bijwerken
+    - Voorwaarden aanpassen
+    - Contactgegevens updaten
+    - Branding vernieuwen
+  </Accordion>
+</AccordionGroup>
+
+## Volgende stappen
+
+<CardGroup cols={2}>
+  <Card
+    title="Facturen maken"
+    icon="file-invoice"
+    href="/nl/essentials/creating-invoices"
+  >
+    Gebruik sjablonen om snel nieuwe facturen te maken
+  </Card>
+  <Card
+    title="Klantenbeheer"
+    icon="users"
+    href="/nl/essentials/customer-management"
+  >
+    Organiseer klantinformatie en voorkeuren
+  </Card>
+</CardGroup>

--- a/nl/essentials/payment-methods.mdx
+++ b/nl/essentials/payment-methods.mdx
@@ -1,0 +1,260 @@
+---
+title: 'Betaalmethoden'
+description: 'Ontdek welke betaalmethoden PayRequest ondersteunt'
+---
+
+# Betaalmethoden
+
+PayRequest ondersteunt een breed scala aan betaalmethoden zodat klanten altijd op de voor hen prettigste manier kunnen betalen. Van traditionele creditcards tot moderne digitale wallets: we hebben alles geregeld.
+
+## Ondersteunde betaalmethoden
+
+<CardGroup cols={2}>
+  <Card title="Credit- & debetcards" icon="credit-card">
+    Accepteer wereldwijd alle grote kaartmerken met veilige verwerking
+  </Card>
+  <Card title="Bankoverschrijvingen" icon="building-columns">
+    Directe bankoverschrijvingen en ACH-betalingen tegen lagere kosten
+  </Card>
+  <Card title="Digitale wallets" icon="wallet">
+    Populaire digitale betaalopties voor moderne klanten
+  </Card>
+  <Card title="Lokale betaalmethoden" icon="globe">
+    Regiospecifieke betaalopties voor internationale klanten
+  </Card>
+</CardGroup>
+
+## Credit- & debetcards
+
+### Ondersteunde kaartmerken
+We accepteren alle belangrijke credit- en debetkaarten:
+
+<Tabs>
+  <Tab title="Belangrijkste merken">
+    - **Visa**: Wereldwijd het meest geaccepteerde kaartmerk
+    - **MasterCard**: Het tweede grootste kaartnetwerk
+    - **American Express**: Premium kaartoptie met hogere kosten
+    - **Discover**: Populair in Noord-Amerika
+    - **Diners Club**: Internationale kaart voor zakenreizigers
+    - **JCB**: Populair in Japan en Azië-Pacific
+  </Tab>
+  <Tab title="Regionale kaarten">
+    - **Maestro**: Europees debetkaartnetwerk
+    - **UnionPay**: Chinees kaartnetwerk
+    - **Cartes Bancaires**: Frans binnenlands kaartsysteem
+    - **Elo**: Braziliaans betaalnetwerk
+    - **Dankort**: Deense betaalkaart
+  </Tab>
+</Tabs>
+
+### Kaartbeveiliging
+<AccordionGroup>
+  <Accordion title="3D Secure-authenticatie" icon="shield-check">
+    Extra beveiliging voor online kaartbetalingen met klantverificatie
+  </Accordion>
+  <Accordion title="CVV-controle" icon="key">
+    Verificatie van de kaartbeveiligingscode bij elke transactie
+  </Accordion>
+  <Accordion title="Fraudepreventie" icon="eye">
+    Geavanceerde systemen voor detectie en preventie van fraude
+  </Accordion>
+</AccordionGroup>
+
+## Bankoverschrijvingen
+
+### Directe bankoverschrijvingen
+Een voordelige optie voor grotere betalingen:
+
+<CardGroup cols={2}>
+  <Card title="ACH-overschrijvingen (VS)" icon="building-columns">
+    - Lagere transactiekosten
+    - Afwikkeling binnen 2-3 werkdagen
+    - Ideaal voor terugkerende betalingen
+    - Minder risico op terugboekingen
+  </Card>
+  <Card title="SEPA-overschrijvingen (Europa)" icon="euro-sign">
+    - Overboekingen in euro's
+    - Zelfde dag of volgende dag verwerkt
+    - Lage kosten voor Europese klanten
+    - Bank-tot-bank veiligheid
+  </Card>
+</CardGroup>
+
+### Internationale overboekingen
+Voor hoge bedragen naar het buitenland:
+- Veilige bank-tot-bank overboekingen
+- Mogelijkheid tot verwerking op dezelfde dag
+- Hogere kosten maar directe afwikkeling
+- Volledige traceerbaarheid van de betaling
+
+## Digitale wallets
+
+### Populaire digitale betaalopties
+
+<Tabs>
+  <Tab title="Mobiele wallets">
+    - **Apple Pay**: Veilige betalingen met Touch ID of Face ID
+    - **Google Pay**: Mobiele betaaloplossing voor Android
+    - **Samsung Pay**: Betaalsysteem voor Samsung-apparaten
+    - **PayPal**: Wereldwijd bekendste digitale wallet
+  </Tab>
+  <Tab title="Online wallets">
+    - **PayPal**: Volledige online betaalomgeving
+    - **Amazon Pay**: Betalingen met Amazon-accounts
+    - **Shop Pay**: Betaaloplossing van Shopify
+    - **Alipay**: Populair in China en Azië
+    - **WeChat Pay**: Betaalplatform binnen sociale media
+  </Tab>
+</Tabs>
+
+### Voordelen van digitale wallets
+- **Sneller afrekenen**: One-click betaalervaring
+- **Verbeterde veiligheid**: Getokeniseerde betaalgegevens
+- **Klantsgemak**: Geen kaartgegevens invoeren
+- **Hogere conversie**: Minder afhakers bij het afrekenen
+
+## Lokale betaalmethoden
+
+### Regionale voorkeuren
+Verschillende regio's hebben hun eigen favoriete betaalmethoden:
+
+<AccordionGroup>
+  <Accordion title="Europa" icon="flag">
+    - **iDEAL** (Nederland): Directe bankbetalingen
+    - **Sofort** (Duitsland): Realtime bankoverschrijvingen
+    - **Bancontact** (België): Lokaal kaartsysteem
+    - **Giropay** (Duitsland): Online bankieren-betalingen
+    - **EPS** (Oostenrijk): Elektronische betaalkoppeling
+  </Accordion>
+  <Accordion title="Azië-Pacific" icon="flag">
+    - **Alipay** (China): Toonaangevend mobiel betaalplatform
+    - **WeChat Pay** (China): Betalen via social media
+    - **GrabPay** (Zuidoost-Azië): Regionaal superapp-betalingen
+    - **Paytm** (India): Populaire Indiase digitale wallet
+  </Accordion>
+  <Accordion title="Latijns-Amerika" icon="flag">
+    - **OXXO** (Mexico): Contante betalingen bij winkels
+    - **Boleto Bancário** (Brazilië): Betaalbewijzen via bank
+    - **PSE** (Colombia): Online bankoverschrijvingen
+    - **PagoEfectivo** (Peru): Netwerk voor contante betalingen
+  </Accordion>
+</AccordionGroup>
+
+## Betaalmethoden configureren
+
+### Betaalmethoden instellen
+Kies welke betaalmethoden je wilt aanbieden:
+
+<Steps>
+  <Step title="Open betalingsinstellingen">
+    Ga in je dashboard naar Instellingen > Betaalmethoden
+  </Step>
+  <Step title="Selecteer methoden">
+    Kies welke betaalmethoden je voor klanten beschikbaar maakt
+  </Step>
+  <Step title="Opties configureren">
+    Stel de specifieke opties per betaalmethode in
+  </Step>
+  <Step title="Test de integratie">
+    Test elke betaalmethode voordat je live gaat
+  </Step>
+</Steps>
+
+### Aanpassingsmogelijkheden
+- **Volgorde van methoden**: Rangschik methoden op voorkeur
+- **Conditionele weergave**: Toon methoden op basis van bedrag of regio
+- **Eigen branding**: Voorzie betaalpagina's van je huisstijl
+- **Kostentoerekening**: Bepaal wie de transactiekosten betaalt
+
+## Verwerkingskosten
+
+### Inzicht in betaalprijzen
+
+<CardGroup cols={2}>
+  <Card title="Kaartbetalingen" icon="credit-card">
+    - Visa/MasterCard: 2,9% + $0,30
+    - American Express: 3,4% + $0,30
+    - Internationale kaarten: +1% extra
+    - Geen maandelijkse kosten
+  </Card>
+  <Card title="Bankoverschrijvingen" icon="building-columns">
+    - ACH-betalingen: 1% (max. $10)
+    - Internationale overboekingen: $15 vast tarief
+    - SEPA-overschrijvingen: €0,35 vast tarief
+    - Geen percentagekosten
+  </Card>
+</CardGroup>
+
+### Tips om kosten te optimaliseren
+<Tip>
+  Stimuleer bankoverschrijvingen voor grotere bedragen om verwerkingskosten te verlagen en je marge te verbeteren.
+</Tip>
+
+- Bied korting bij grote facturen die via bankoverschrijving betaald worden
+- Stel minimum bedragen in voor kaartbetalingen
+- Overweeg kosten door te belasten bij kleine transacties
+- Gebruik ACH voor terugkerende betalingen waar mogelijk
+
+## Veiligheid en compliance
+
+### Betaalbeveiligingsstandaarden
+Alle betaalmethoden zijn beveiligd met:
+
+<AccordionGroup>
+  <Accordion title="PCI DSS-naleving" icon="shield-check">
+    Voldoet aan de Payment Card Industry Data Security Standard voor kaartverwerking
+  </Accordion>
+  <Accordion title="Encryptie" icon="lock">
+    End-to-end encryptie voor alle betaalgegevens
+  </Accordion>
+  <Accordion title="Tokenisatie" icon="key">
+    Veilig tokens opslaan in plaats van daadwerkelijke betaalinformatie
+  </Accordion>
+</AccordionGroup>
+
+## Best practices
+
+### Succes van betalingen optimaliseren
+- **Bied meerdere opties aan**: Geef klanten keuze uit betaalmethoden
+- **Lokale voorkeuren**: Activeer regionale methoden voor internationale klanten
+- **Heldere prijzen**: Toon alle kosten transparant
+- **Mobiel geoptimaliseerd**: Zorg dat alle methoden mobiel werken
+
+### Klantbeleving verbeteren
+- **One-click betalen**: Laat terugkerende klanten betaalmethoden opslaan
+- **Gastafrekenen**: Sta betalingen zonder account toe
+- **Betalingsbevestiging**: Verstuur direct een bevestiging
+- **Bonbeheer**: Geef eenvoudig toegang tot betalingsbewijzen
+
+## Volgende stappen
+
+<CardGroup cols={2}>
+  <Card
+    title="Facturen maken"
+    icon="file-invoice"
+    href="/nl/essentials/creating-invoices"
+  >
+    Leer hoe je facturen maakt met verschillende betaalopties
+  </Card>
+  <Card
+    title="Klantenbeheer"
+    icon="users"
+    href="/nl/essentials/customer-management"
+  >
+    Bewaar klantvoorkeuren voor betaalmethoden
+  </Card>
+  <Card
+    title="Betalingen bijhouden"
+    icon="chart-line"
+    href="/nl/essentials/tracking-payments"
+  >
+    Monitor de prestaties per betaalmethode
+  </Card>
+  <Card
+    title="Beveiliging"
+    icon="shield"
+    href="/nl/essentials/security"
+  >
+    Leer meer over best practices voor betaalbeveiliging
+  </Card>
+</CardGroup>

--- a/nl/essentials/payment-tracking.mdx
+++ b/nl/essentials/payment-tracking.mdx
@@ -1,0 +1,60 @@
+---
+title: 'Betalingen volgen'
+description: 'Monitor en analyseer je betaalprestaties'
+---
+
+# Betalingen volgen
+
+(Dit is dezelfde inhoud als tracking-payments.mdx, maar geplaatst onder Business Workflows)
+
+Monitor de factuurstatus en volg betalingsvoortgang met de uitgebreide trackingtools van PayRequest. Blijf grip houden op je cashflow en begrijp je betaalpatronen.
+
+<CardGroup cols={3}>
+  <Card title="Realtime updates" icon="activity">
+    Ontvang directe meldingen wanneer facturen worden bekeken of betaald
+  </Card>
+  <Card title="Prestatie-analyses" icon="chart-line">
+    Analyseer betaaltrends en klantgedrag
+  </Card>
+  <Card title="Automatische herinneringen" icon="bell">
+    Stel automatische opvolging in voor achterstallige betalingen
+  </Card>
+</CardGroup>
+
+## Snel overzicht
+
+Voor uitgebreide informatie over betalingsopvolging, bekijk onze volledige gids:
+
+<Card
+  title="Volledige gids betalingen volgen"
+  icon="external-link"
+  href="/nl/essentials/tracking-payments"
+>
+  Toegang tot uitgebreide documentatie met functies, analyses en best practices
+</Card>
+
+## Belangrijkste functies
+
+- **Factuurstatus monitoren**: Volg concept, verzonden, bekeken en betaalde status
+- **Betaalgedrag van klanten**: Begrijp hoe en wanneer klanten betalen
+- **Achterstallig beheer**: Identificeer en volg achterstallige betalingen op
+- **Prestatie-rapportages**: Genereer inzichten in betaalefficiëntie
+
+## Volgende stappen
+
+<CardGroup cols={2}>
+  <Card
+    title="Complete trackinggids"
+    icon="book-open"
+    href="/nl/essentials/tracking-payments"
+  >
+    Lees de volledige documentatie over betalingen volgen
+  </Card>
+  <Card
+    title="Klantenbeheer"
+    icon="users"
+    href="/nl/essentials/customer-management"
+  >
+    Organiseer klantinformatie en betalingshistorie
+  </Card>
+</CardGroup>

--- a/nl/essentials/payments.mdx
+++ b/nl/essentials/payments.mdx
@@ -1,0 +1,191 @@
+---
+title: 'Betalingen begrijpen'
+description: 'Leer hoe betalingen in PayRequest werken'
+---
+
+# Betalingen begrijpen
+
+Betalingen vormen de kern van het PayRequest-platform. Een betaling is een verzoek om geld van een klant, dat via verschillende betaalmethoden kan worden voldaan.
+
+## Levenscyclus van een betaling
+
+Elke betaling in PayRequest doorloopt een voorspelbare levenscyclus:
+
+<Steps>
+  <Step title="Gemaakt">
+    Er wordt een betaalverzoek aangemaakt met een bedrag, beschrijving en optioneel ontvangerinformatie.
+  </Step>
+  <Step title="In afwachting">
+    De betaling wacht totdat de klant de transactie afrondt.
+  </Step>
+  <Step title="Verwerken">
+    De klant heeft een betaling gestart en deze wordt verwerkt door de betaalprovider.
+  </Step>
+  <Step title="Voltooid">
+    De betaling is succesvol verwerkt en de middelen worden overgemaakt.
+  </Step>
+</Steps>
+
+## Betalingsstatussen
+
+<AccordionGroup>
+  <Accordion title="pending" icon="clock">
+    Het betaalverzoek is aangemaakt en wacht op de klant.
+  </Accordion>
+  <Accordion title="processing" icon="gear">
+    De klant heeft betaald en de transactie wordt verwerkt.
+  </Accordion>
+  <Accordion title="completed" icon="check">
+    De betaling is succesvol afgerond.
+  </Accordion>
+  <Accordion title="failed" icon="x">
+    De betalingspoging is mislukt (bijv. onvoldoende saldo, geweigerde kaart).
+  </Accordion>
+  <Accordion title="cancelled" icon="ban">
+    Het betaalverzoek is vóór afronding geannuleerd.
+  </Accordion>
+  <Accordion title="expired" icon="calendar-x">
+    Het betaalverzoek is verlopen voordat de klant kon betalen.
+  </Accordion>
+</AccordionGroup>
+
+## Betaalmethoden
+
+PayRequest ondersteunt meerdere betaalmethoden zodat je wereldwijd klanten kunt bedienen:
+
+<CardGroup cols={2}>
+  <Card title="Credit- & debetcards" icon="credit-card">
+    Visa, MasterCard, American Express en andere grote kaartmerken
+  </Card>
+  <Card title="Bankoverschrijvingen" icon="building-columns">
+    Directe bankoverschrijvingen en ACH-betalingen
+  </Card>
+  <Card title="Digitale wallets" icon="wallet">
+    Apple Pay, Google Pay, PayPal en andere digitale wallets
+  </Card>
+  <Card title="Lokale methoden" icon="globe">
+    Land-specifieke betaalmethoden zoals iDEAL, SEPA en meer
+  </Card>
+</CardGroup>
+
+## Betaal-URL's
+
+Wanneer je een betaling aanmaakt, genereert PayRequest een unieke betaal-URL die je met je klant kunt delen:
+
+```
+https://payrequest.io/p/pay_1234567890
+```
+
+Deze URL biedt een veilige, gehoste betaalpagina waar klanten met hun voorkeursmethode kunnen betalen.
+
+### Betaalpagina's aanpassen
+
+Pas de betaalpagina aan zodat deze aansluit bij je merk:
+
+- **Logo**: Upload je bedrijfslogo
+- **Kleuren**: Gebruik je huisstijlkleuren
+- **Eigen domein**: Gebruik je eigen domein (bijv. pay.jouwbedrijf.com)
+- **Succes/annulatie-URL's**: Stuur klanten na betaling door
+
+## Betalingsmetadata
+
+Koppel aangepaste metadata aan betalingen voor interne opvolging:
+
+```json
+{
+  "metadata": {
+    "order_id": "ORD-12345",
+    "customer_segment": "premium",
+    "source": "website"
+  }
+}
+```
+
+Metadata wordt teruggestuurd in webhooks en API-responses, zodat je betalingen eenvoudig koppelt aan interne systemen.
+
+## Verval en herinneringen
+
+<Tabs>
+  <Tab title="Vervaldatum betaling">
+    Stel een vervaldatum in voor betaalverzoeken:
+
+    ```json
+    {
+      "expires_at": "2024-12-31T23:59:59Z"
+    }
+    ```
+
+    Verlopen betalingen kunnen niet meer worden afgerond en tonen een passend bericht aan klanten.
+  </Tab>
+
+  <Tab title="Automatische herinneringen">
+    Configureer automatische e-mailherinneringen voor openstaande betalingen:
+
+    - **Eerste herinnering**: 3 dagen na aanmaak
+    - **Tweede herinnering**: 7 dagen na aanmaak
+    - **Laatste herinnering**: 1 dag voor de vervaldatum
+
+    Herinneringen kun je per betaling aanpassen of uitschakelen.
+  </Tab>
+</Tabs>
+
+## Veiligheidsaspecten
+
+<Warning>
+  Valideer betalingen altijd via webhooks of API-calls en vertrouw niet alleen op redirect-URL's. Klanten kunnen hun browser sluiten voordat de redirect plaatsvindt.
+</Warning>
+
+- **Webhook-verificatie**: Controleer altijd webhookhandtekeningen
+- **Alleen HTTPS**: Gebruik HTTPS voor alle callback-URL's
+- **Idempotency**: Gebruik idempotency keys bij het aanmaken van betalingen
+- **Gevoelige data**: Zet nooit gevoelige informatie in metadata
+
+## Betalingen testen
+
+Gebruik in sandboxmodus deze testkaartnummers:
+
+<AccordionGroup>
+  <Accordion title="Succesvolle betalingen">
+    - **4111 1111 1111 1111** - Visa (succesvol)
+    - **5555 5555 5555 4444** - MasterCard (succesvol)
+    - **3782 822463 10005** - American Express (succesvol)
+  </Accordion>
+  <Accordion title="Mislukte betalingen">
+    - **4000 0000 0000 0002** - Kaart geweigerd
+    - **4000 0000 0000 9995** - Onvoldoende saldo
+    - **4000 0000 0000 0119** - Verwerkingsfout
+  </Accordion>
+</AccordionGroup>
+
+## Volgende stappen
+
+<CardGroup cols={2}>
+  <Card
+    title="Maak je eerste factuur"
+    icon="file-invoice"
+    href="/nl/essentials/creating-invoices"
+  >
+    Leer hoe je professionele facturen maakt
+  </Card>
+  <Card
+    title="Webhooks instellen"
+    icon="webhook"
+    href="/nl/essentials/webhooks"
+  >
+    Ontvang realtime betalingsmeldingen
+  </Card>
+  <Card
+    title="Betaalmethoden"
+    icon="credit-card"
+    href="/nl/essentials/payment-methods"
+  >
+    Ontdek de beschikbare betaalopties
+  </Card>
+  <Card
+    title="Betalingen bijhouden"
+    icon="chart-line"
+    href="/nl/essentials/tracking-payments"
+  >
+    Monitor je betaalprestaties
+  </Card>
+</CardGroup>

--- a/nl/essentials/reporting.mdx
+++ b/nl/essentials/reporting.mdx
@@ -1,0 +1,230 @@
+---
+title: 'Rapportages'
+description: 'Genereer gedetailleerde financiële rapporten en analyses'
+---
+
+# Rapportages
+
+Krijg inzicht in je bedrijfsresultaten met de uitgebreide rapportagetools van PayRequest. Maak gedetailleerde financiële rapporten, volg belangrijke statistieken en neem datagedreven beslissingen om te groeien.
+
+## Soorten rapporten
+
+<CardGroup cols={2}>
+  <Card title="Financiële rapporten" icon="chart-bar">
+    Resultatenrekeningen, cashflow-rapporten en omzetanalyses
+  </Card>
+  <Card title="Klantrapporten" icon="users">
+    Betaalgedrag, customer lifetime value en segmentatie
+  </Card>
+  <Card title="Factuurrapporten" icon="file-invoice">
+    Factuurprestaties, verouderingsrapporten en incassostatistieken
+  </Card>
+  <Card title="Betaalrapporten" icon="credit-card">
+    Analyse van betaalmethoden, succesratio's en transactiedetails
+  </Card>
+</CardGroup>
+
+## Financiële analyses
+
+### Omzet bijhouden
+Volg de inkomsten van je bedrijf:
+
+<Tabs>
+  <Tab title="Omzetoverzicht">
+    - Maandelijkse en jaarlijkse omzettrends
+    - Omzet per klantsegment
+    - Prestatie per dienst of product
+    - Verwachte inkomsten uit openstaande facturen
+  </Tab>
+  <Tab title="Cashflow-analyse">
+    - Dagelijkse, wekelijkse en maandelijkse cashflow
+    - Seizoenspatronen en trends
+    - Effect van openstaande facturen
+    - Analyse van betalingstiming
+  </Tab>
+</Tabs>
+
+### Prestatie-indicatoren
+
+<AccordionGroup>
+  <Accordion title="Incassostatistieken" icon="target">
+    - Gemiddelde tijd tot betaling
+    - Succesratio van incasso
+    - Percentage achterstallige facturen
+    - Betrouwbaarheid van klanten
+  </Accordion>
+  <Accordion title="Bedrijfsgroei" icon="trending-up">
+    - Maand-op-maand-groei
+    - Trends in klantacquisitie
+    - Omzet per klant
+    - Metrics voor marktuitbreiding
+  </Accordion>
+</AccordionGroup>
+
+## Klantanalyses
+
+### Analyse van betaalgedrag
+Krijg beter inzicht in klanten:
+
+<CardGroup cols={3}>
+  <Card title="Betaalsnelheid" icon="stopwatch">
+    Hoe snel klanten facturen voldoen
+  </Card>
+  <Card title="Voorkeursmethoden" icon="credit-card">
+    Welke betaalmethoden klanten kiezen
+  </Card>
+  <Card title="Reactie op communicatie" icon="message-circle">
+    Hoe klanten reageren op herinneringen en opvolging
+  </Card>
+</CardGroup>
+
+### Segmentatierapporten
+- **Hoogwaardige klanten**: Je meest winstgevende relaties
+- **Betrouwbare betalers**: Klanten die consequent op tijd betalen
+- **Risicoklanten**: Afnemers met afnemend betaalgedrag
+- **Groeikansen**: Klanten met uitbreidingspotentieel
+
+## Factuurprestaties
+
+### Verouderingsrapporten
+Volg openstaande facturen naar ouderdom:
+
+<Steps>
+  <Step title="Actueel (0-30 dagen)">
+    Recent verstuurde facturen binnen de betaaltermijn
+  </Step>
+  <Step title="30-60 dagen">
+    Facturen die licht achterstallig zijn
+  </Step>
+  <Step title="60-90 dagen">
+    Aanzienlijk achterstallige facturen die actie vereisen
+  </Step>
+  <Step title="90+ dagen">
+    Ernstig achterstallige facturen voor incasso
+  </Step>
+</Steps>
+
+### Factuuranalyses
+- **Conversieratio's**: Van verstuurd naar betaald
+- **Bekijkratio's**: Hoeveel klanten facturen openen
+- **Succes van betaalmethoden**: Welke methode het beste werkt
+- **Tijd tot betaling**: Gemiddelde doorlooptijd
+
+## Aangepaste rapporten
+
+### Rapportbuilder
+Maak rapporten op maat voor jouw situatie:
+
+<Tabs>
+  <Tab title="Dataselectie">
+    - Kies datumbereiken
+    - Selecteer klantsegmenten
+    - Filter op factuurstatus
+    - Neem specifieke metrics op
+  </Tab>
+  <Tab title="Visualisatie">
+    - Kies grafiektypes en opmaak
+    - Pas kleuren en branding aan
+    - Exporteer in PDF, CSV of Excel
+    - Plan automatische verzending
+  </Tab>
+</Tabs>
+
+## Export en integraties
+
+### Data-exportopties
+
+<AccordionGroup>
+  <Accordion title="Boekhoudintegraties" icon="calculator">
+    - Synchronisatie met QuickBooks
+    - Export naar Xero
+    - Wave Accounting-integratie
+    - Aangepaste boekhoudformaten
+  </Accordion>
+  <Accordion title="Business intelligence" icon="brain">
+    - Koppeling met Power BI
+    - Tableau-datafeeds
+    - Integratie met Google Analytics
+    - Eigen dashboards bouwen
+  </Accordion>
+</AccordionGroup>
+
+## Automatische rapportage
+
+### Geplande rapporten
+Plan automatische rapportgeneratie:
+
+- **Dagelijkse overzichten**: Snelle blik op dagelijkse activiteiten
+- **Wekelijkse prestaties**: Wekelijkse bedrijfsstatistieken
+- **Maandelijkse cijfers**: Uitgebreide maandrapporten
+- **Kwartaalreviews**: Gedetailleerde kwartaalanalyses
+
+### Rapportbezorging
+Kies hoe je rapporten wilt ontvangen:
+- **E-mailbezorging**: Automatische e-mails met rapportbijlagen
+- **Dashboardmeldingen**: In-app notificaties met kerncijfers
+- **API-toegang**: Programmeerbare toegang tot rapportdata
+- **Mobiele meldingen**: Belangrijke metrics op je telefoon
+
+## Best practices
+
+### Vast ritme voor review
+<Tip>
+  Stel een vast rapportageschema in om zicht te houden op prestaties en trends snel te herkennen.
+</Tip>
+
+- **Dagelijks**: Controleer cashflow en betaalactiviteit
+- **Wekelijks**: Bekijk achterstallige facturen en klantissues
+- **Maandelijks**: Analyseer de totale bedrijfsperformance
+- **Elk kwartaal**: Strategische planning en doelbewaking
+
+### Belangrijkste metrics
+Focus op de belangrijkste indicatoren:
+
+<CardGroup cols={2}>
+  <Card title="Financiële gezondheid" icon="heart-pulse">
+    - Maandelijkse terugkerende omzet
+    - Cashflow-trends
+    - Openstaande vorderingen
+    - Marges
+  </Card>
+  <Card title="Operationele efficiëntie" icon="gauge">
+    - Gemiddelde betalingstermijn
+    - Snelheid van factuurcreatie
+    - Reactiepercentages van klanten
+    - Succes van incasso
+  </Card>
+</CardGroup>
+
+## Volgende stappen
+
+<CardGroup cols={2}>
+  <Card
+    title="Betalingen volgen"
+    icon="chart-line"
+    href="/nl/essentials/payment-tracking"
+  >
+    Leer meer over realtime betalingsmonitoring
+  </Card>
+  <Card
+    title="Klantenbeheer"
+    icon="users"
+    href="/nl/essentials/customer-management"
+  >
+    Organiseer klantgegevens voor betere rapportages
+  </Card>
+  <Card
+    title="Facturen maken"
+    icon="file-invoice"
+    href="/nl/essentials/creating-invoices"
+  >
+    Optimaliseer facturatie voor betere rapportages
+  </Card>
+  <Card
+    title="Dashboard"
+    icon="external-link"
+    href="https://dashboard.payrequest.io"
+  >
+    Ga naar je PayRequest-dashboard om rapporten te genereren
+  </Card>
+</CardGroup>

--- a/nl/essentials/security.mdx
+++ b/nl/essentials/security.mdx
@@ -1,0 +1,283 @@
+---
+title: 'Beveiliging'
+description: 'Lees meer over de beveiligingsmaatregelen en best practices van PayRequest'
+---
+
+# Beveiliging
+
+PayRequest neemt beveiliging zeer serieus. We gebruiken toonaangevende beveiligingsmaatregelen om je bedrijf en klantgegevens te beschermen, veilige betalingsverwerking te garanderen en te voldoen aan internationale normen.
+
+## Platformbeveiliging
+
+<CardGroup cols={2}>
+  <Card title="Gegevensencryptie" icon="lock">
+    Alle data wordt versleuteld tijdens transport en in rust met AES-256-encryptie
+  </Card>
+  <Card title="PCI DSS-compliant" icon="shield-check">
+    Betaalinfrastructuur die voldoet aan PCI DSS Level 1
+  </Card>
+  <Card title="SOC 2-gecertificeerd" icon="certificate">
+    SOC 2 Type II-certificering voor security, beschikbaarheid en vertrouwelijkheid
+  </Card>
+  <Card title="GDPR-conform" icon="scale">
+    Volledige naleving van de Europese privacywetgeving
+  </Card>
+</CardGroup>
+
+## Betalingsbeveiliging
+
+### Veilige betalingsverwerking
+Je klantbetalingen zijn beschermd door:
+
+<Tabs>
+  <Tab title="Tokenisatie">
+    - Betaalinformatie wordt vervangen door veilige tokens
+    - Geen gevoelige data opgeslagen op onze servers
+    - Minder PCI-complianceverplichtingen voor jouw bedrijf
+    - Betere bescherming tegen datalekken
+  </Tab>
+  <Tab title="3D Secure">
+    - Extra authenticatielaag voor kaartbetalingen
+    - Minder fraude en chargebacks
+    - Voldoet aan Strong Customer Authentication (SCA)
+    - Ondersteunt zowel 3DS 1.0 als 3DS 2.0
+  </Tab>
+</Tabs>
+
+### Fraudepreventie
+Geavanceerde fraudedetectie omvat:
+
+<AccordionGroup>
+  <Accordion title="Machine learning" icon="brain">
+    AI-gestuurde fraudedetectie die leert van transactiepatronen
+  </Accordion>
+  <Accordion title="Risicoscoring" icon="chart-line">
+    Realtime risico-inschatting bij elke transactie
+  </Accordion>
+  <Accordion title="Snelheidscontroles" icon="gauge">
+    Bewaking op ongebruikelijke transactiesnelheid of patronen
+  </Accordion>
+  <Accordion title="Geolocatieanalyse" icon="globe">
+    Fraudepreventie op basis van locatiegegevens
+  </Accordion>
+</AccordionGroup>
+
+## Gegevensbescherming
+
+### Beveiliging van klantdata
+We beschermen klantinformatie met:
+
+<CardGroup cols={3}>
+  <Card title="Toegangscontrole" icon="key">
+    Multi-factor-authenticatie en rolgebaseerde toegang
+  </Card>
+  <Card title="Dataminimalisatie" icon="minimize">
+    We verzamelen alleen informatie die nodig is voor betalingen
+  </Card>
+  <Card title="Regelmatige audits" icon="search">
+    Continue monitoring en periodieke audits
+  </Card>
+</CardGroup>
+
+### Privacybescherming
+- **Data-anonimisering**: Persoonsgegevens worden waar mogelijk geanonimiseerd
+- **Recht op verwijdering**: Klanten kunnen gegevens laten verwijderen (GDPR)
+- **Dataportabiliteit**: Exporteer klantdata op verzoek
+- **Toestemmingsbeheer**: Heldere registratie van klanttoestemming
+
+## Infrastructuurbeveiliging
+
+### Veilige hosting
+De infrastructuur van PayRequest bestaat uit:
+
+<Tabs>
+  <Tab title="Cloudbeveiliging">
+    - AWS-hosting met enterprise-beveiliging
+    - Meerdere availability zones voor redundantie
+    - DDoS-bescherming en verkeersfiltering
+    - Regelmatige securitypatches en updates
+  </Tab>
+  <Tab title="Netwerkbeveiliging">
+    - Privénetwerken en VPC's
+    - Web Application Firewall (WAF)
+    - Intrusion detection & prevention
+    - 24/7 beveiligingsmonitoring
+  </Tab>
+</Tabs>
+
+### Back-up en herstel
+- **Automatische back-ups**: Dagelijkse versleutelde back-ups van alle data
+- **Disaster recovery**: Uitgebreid herstelplan bij calamiteiten
+- **Business continuity**: 99,9% uptime SLA
+- **Gegevensherstel**: Point-in-time recovery mogelijkheden
+
+## Accountbeveiliging
+
+### Gebruikersauthenticatie
+Bescherm je PayRequest-account met:
+
+<Steps>
+  <Step title="Sterke wachtwoorden">
+    Gebruik complexe wachtwoorden met letters, cijfers en symbolen
+  </Step>
+  <Step title="Twee-factor-authenticatie">
+    Schakel 2FA in voor een extra beveiligingslaag
+  </Step>
+  <Step title="Regelmatige controles">
+    Bekijk periodiek de accounttoegang en permissies
+  </Step>
+  <Step title="Veilige sessies">
+    Automatische sessietime-outs en veilig sessiebeheer
+  </Step>
+</Steps>
+
+### API-beveiliging
+Voor bedrijven die onze API gebruiken:
+
+<AccordionGroup>
+  <Accordion title="API-sleutels" icon="key">
+    - Veilige generatie en beheer van API-sleutels
+    - Gescheiden sleutels voor test- en live-omgeving
+    - Beleid voor rotatie en vervaldatum
+    - Rate limiting om misbruik te voorkomen
+  </Accordion>
+  <Accordion title="Webhook-beveiliging" icon="webhook">
+    - Ondertekende webhook-payloads voor verificatie
+    - Alleen HTTPS-webhooks toegestaan
+    - Retry-mechanisme met exponentiële back-off
+    - Validatie van webhook-handtekeningen
+  </Accordion>
+</AccordionGroup>
+
+## Compliance-standaarden
+
+### Wettelijke compliance
+PayRequest voldoet aan:
+
+<CardGroup cols={2}>
+  <Card title="PCI DSS" icon="credit-card">
+    Payment Card Industry Data Security Standard Level 1
+  </Card>
+  <Card title="GDPR" icon="scale">
+    Europese privacywetgeving voor klanten in de EU
+  </Card>
+  <Card title="CCPA" icon="flag">
+    California Consumer Privacy Act
+  </Card>
+  <Card title="SOX" icon="building">
+    Sarbanes-Oxley compliance voor financiële rapportages
+  </Card>
+</CardGroup>
+
+### Industriestandaarden
+- **ISO 27001**: Managementsysteem voor informatiebeveiliging
+- **SOC 2 Type II**: Security, beschikbaarheid en vertrouwelijkheid
+- **SSAE 18**: Standaard voor assurance-rapportages
+- **FedRAMP**: Framework voor risicobeheer bij overheden
+
+## Best practices voor beveiliging
+
+### Voor jouw organisatie
+<Tip>
+  Pas deze beveiligingsmaatregelen toe om je bedrijf en klanten te beschermen.
+</Tip>
+
+**Accountbeheer:**
+- Gebruik sterke, unieke wachtwoorden voor alle accounts
+- Schakel twee-factor-authenticatie (2FA) in
+- Controleer regelmatig gebruikersrechten en toegang
+- Houd activiteiten in de gaten op verdachte signalen
+
+**Factuurbeveiliging:**
+- Neem duidelijke voorwaarden op in facturen
+- Gebruik uitsluitend veilige betaallinks
+- Verifieer e-mailadressen van klanten
+- Let op verdachte betaalpogingen
+
+### Voor je klanten
+Help klanten veilig te blijven:
+
+**Beste betaalpraktijken:**
+- Gebruik altijd beveiligde betaalpagina's (HTTPS)
+- Deel nooit betaalinformatie via e-mail
+- Controleer de echtheid van facturen voor betaling
+- Bewaar betaalbewijzen als naslag
+
+**Communicatiebeveiliging:**
+- Gebruik uitsluitend officiële PayRequest-domeinen
+- Controleer verdachte communicatie rechtstreeks
+- Meld mogelijke phishingpogingen
+- Informeer klanten over betaalveiligheid
+
+## Incidentrespons
+
+### Security monitoring
+We monitoren continu op:
+
+<AccordionGroup>
+  <Accordion title="Threat detection" icon="eye">
+    24/7 monitoring van beveiligingsdreigingen en afwijkingen
+  </Accordion>
+  <Accordion title="Kwetsbaarheidsbeheer" icon="bug">
+    Regelmatige security-assessments en patching
+  </Accordion>
+  <Accordion title="Incidentrespons" icon="alert-triangle">
+    Een snel reactieteam voor beveiligingsincidenten
+  </Accordion>
+</AccordionGroup>
+
+### Beveiligingsproblemen melden
+Ontdek je een beveiligingsprobleem?
+
+1. **Maak het niet openbaar** – Neem eerst rechtstreeks contact op
+2. **Mail naar security@payrequest.io** met details
+3. **Voeg stappen toe om te reproduceren** indien mogelijk
+4. **We reageren binnen 24 uur** met een bevestiging
+5. **Je ontvangt updates** tijdens het onderzoek
+
+## Beveiligingscertificeringen
+
+### Huidige certificeringen
+- **PCI DSS Level 1** – Hoogste niveau van betaalbeveiliging
+- **SOC 2 Type II** – Onafhankelijk getoetste securitycontroles
+- **ISO 27001** – Internationale norm voor informatiebeveiliging
+- **AWS Security Partner** – Geverifieerde cloudbeveiligingspraktijken
+
+### Periodieke audits
+- **Jaarlijkse PCI DSS-audits** door erkende assessors
+- **Kwartaalelijkse vulnerability-scans** door gecertificeerde partijen
+- **Penetratietesten** door externe securityspecialisten
+- **Security code reviews** voor alle applicatiewijzigingen
+
+## Volgende stappen
+
+<CardGroup cols={2}>
+  <Card
+    title="Twee-factor-authenticatie"
+    icon="shield"
+    href="https://dashboard.payrequest.io/settings/security"
+  >
+    Schakel 2FA in op je PayRequest-account
+  </Card>
+  <Card
+    title="Webhooks beveiligen"
+    icon="webhook"
+    href="/nl/essentials/webhooks"
+  >
+    Leer hoe je webhooks veilig implementeert
+  </Card>
+  <Card
+    title="Betaalmethoden"
+    icon="credit-card"
+    href="/nl/essentials/payment-methods"
+  >
+    Begrijp veilige betaalopties
+  </Card>
+  <Card
+    title="Support"
+    icon="life-ring"
+    href="mailto:support@payrequest.io"
+  >
+    Neem contact op met ons securityteam
+  </Card>
+</CardGroup>

--- a/nl/essentials/sending-invoices.mdx
+++ b/nl/essentials/sending-invoices.mdx
@@ -1,0 +1,315 @@
+---
+title: 'Facturen verzenden'
+description: 'Leer hoe je facturen naar klanten verstuurt en de aflevering beheert'
+---
+
+# Facturen verzenden
+
+Zodra je factuur klaar is, biedt PayRequest meerdere manieren om deze snel en professioneel naar je klanten te sturen. Deze gids bespreekt alle verzendopties en best practices om je facturen bij klanten te bezorgen.
+
+## Methoden om facturen te bezorgen
+
+<CardGroup cols={2}>
+  <Card title="Verzenden via e-mail" icon="envelope">
+    Verstuur facturen rechtstreeks vanuit PayRequest met professionele e-mailsjablonen
+  </Card>
+  <Card title="Deelbare links" icon="link">
+    Genereer veilige links die je via elk kanaal kunt delen
+  </Card>
+  <Card title="PDF-download" icon="file-pdf">
+    Download facturen als pdf voor offline delen of printen
+  </Card>
+  <Card title="Directe integratie" icon="plug">
+    Embed facturen in je website of klantenportaal
+  </Card>
+</CardGroup>
+
+## Facturen via e-mail
+
+### Verzenden met PayRequest
+De meest gebruikte verzendmethode:
+
+<Steps>
+  <Step title="Controleer de factuur">
+    Controleer alle details zoals klant e-mail, bedragen en vervaldatums.
+  </Step>
+  <Step title="Pas de e-mail aan">
+    Voeg een persoonlijk bericht toe of kies een van onze professionele sjablonen.
+  </Step>
+  <Step title="Verzend de factuur">
+    Klik op **Factuur verzenden** om direct te versturen of plan een later moment in.
+  </Step>
+  <Step title="Volg de aflevering">
+    Houd bij wanneer de e-mail is afgeleverd en of klanten de factuur openen.
+  </Step>
+</Steps>
+
+### E-mailsjablonen
+Kies uit professionele sjablonen of maak je eigen variant:
+
+<Tabs>
+  <Tab title="Standaardsjablonen">
+    - **Professioneel**: Zakelijk en overzichtelijk
+    - **Vriendelijk**: Warme toon voor kleine bedrijven
+    - **Minimalistisch**: Simpel ontwerp met essentiële info
+    - **Uitgebreid**: Compleet sjabloon met betaalinstructies
+  </Tab>
+  <Tab title="Eigen sjablonen">
+    Maak je eigen e-mailsjablonen:
+    - Gebruik je eigen tone of voice
+    - Voeg standaardbetalingsvoorwaarden toe
+    - Neem contactgegevens op
+    - Voeg eigen instructies of beleid toe
+  </Tab>
+</Tabs>
+
+### E-mail personaliseren
+Maak elke factuur-e-mail persoonlijk:
+
+```
+Onderwerp: Factuur #INV-2024-001 van [Bedrijfsnaam]
+
+Beste [Klantnaam],
+
+Bijgaand vind je je factuur voor [Omschrijving dienst/product].
+
+De betaling dient uiterlijk [Vervaldatum] te worden voldaan. Je kunt veilig online betalen via onderstaande link:
+
+[Betaal nu-knop]
+
+Heb je vragen, laat het me gerust weten.
+
+Met vriendelijke groet,
+[Je naam]
+[Bedrijfsnaam]
+```
+
+## Deelbare factuurlinks
+
+Genereer veilige links voor flexibele verzending:
+
+### Link maken
+1. Klik op **Deelbare link ophalen** bij een factuur
+2. Kopieer de gegenereerde URL
+3. Deel via e-mail, sms, chat of social media
+4. Volg wanneer de link is geopend
+
+### Linkfuncties
+<AccordionGroup>
+  <Accordion title="Beveiliging" icon="shield">
+    - Unieke, niet te raden URL's
+    - Optionele wachtwoordbeveiliging
+    - Mogelijkheid om een verloopdatum in te stellen
+    - Logging en tracking van toegang
+  </Accordion>
+  <Accordion title="Personalisatie" icon="palette">
+    - Eigen domein (pay.jouwbedrijf.com)
+    - Betaalpagina's in jouw huisstijl
+    - Je logo en kleuren
+    - Aangepaste succes- en foutmeldingen
+  </Accordion>
+</AccordionGroup>
+
+## Facturen in bulk versturen
+
+Verstuur meerdere facturen tegelijk:
+
+### Bulk-e-mail
+Ideaal voor maandelijkse facturatie of terugkerende facturen:
+1. Selecteer meerdere facturen in het dashboard
+2. Kies **Geselecteerde facturen verzenden**
+3. Pas het e-mailsjabloon aan indien nodig
+4. Verstuur alle facturen in één keer
+
+### Gepland verzenden
+Automatiseer je factuuraflevering:
+- Plan facturen op specifieke datums
+- Stel schema's in voor terugkerende facturen
+- Verstuur automatisch opvolgherinneringen
+- Timing afstemmen op kantooruren
+
+## Facturen volgen
+
+Houd de aflevering en betrokkenheid bij:
+
+<CardGroup cols={3}>
+  <Card title="Verzendstatus" icon="truck">
+    - Succesvol verzonden
+    - E-mail afgeleverd
+    - E-mail gebounced/mislukt
+    - Aflevering in behandeling
+  </Card>
+  <Card title="Klantbetrokkenheid" icon="eye">
+    - Factuur bekeken
+    - Tijd dat de factuur is bekeken
+    - Aantal weergaven
+    - Eventueel gedeeld
+  </Card>
+  <Card title="Betaalvoortgang" icon="credit-card">
+    - Betaalpagina bezocht
+    - Betalingspoging gedaan
+    - Betaling voltooid
+    - Betaling mislukt
+  </Card>
+</CardGroup>
+
+## Klantcommunicatie
+
+### Opvolgberichten
+Blijf in contact zonder opdringerig te zijn:
+
+<Tabs>
+  <Tab title="Automatische herinneringen">
+    Stel automatische e-mailherinneringen in:
+    - 3 dagen voor vervaldatum: vriendelijke reminder
+    - Op de vervaldag: betalingsherinnering
+    - 3 dagen te laat: eerste opvolging
+    - 7 dagen te laat: tweede opvolging
+    - 14 dagen te laat: laatste waarschuwing
+  </Tab>
+  <Tab title="Handmatige opvolging">
+    Verstuur persoonlijke berichten:
+    - Check of de factuur ontvangen is
+    - Beantwoord vragen over de dienstverlening
+    - Onderhandel indien nodig over betalingsvoorwaarden
+    - Houd de relatie positief
+  </Tab>
+</Tabs>
+
+### Klanten ondersteunen
+Help klanten bij vragen over facturen:
+
+<AccordionGroup>
+  <Accordion title="Veelgestelde vragen" icon="question">
+    - Hoe betaal ik de factuur?
+    - Welke betaalmethoden zijn beschikbaar?
+    - Is betalen veilig?
+    - Hoe download ik een betalingsbewijs?
+    - Kan ik uitstel aanvragen?
+  </Accordion>
+  <Accordion title="Supporttools" icon="tools">
+    - Ingebouwde klantenchat
+    - FAQ-sectie op betaalpagina's
+    - Directe contactgegevens
+    - Videotutorials voor klanten
+  </Accordion>
+</AccordionGroup>
+
+## Mobielvriendelijke aflevering
+
+Zorg dat klanten vanaf elk apparaat kunnen betalen:
+
+### Mobiele optimalisatie
+- Responsief factuurontwerp
+- Grote, touchvriendelijke betaalknoppen
+- Goed leesbaar op kleine schermen
+- Snelle laadtijden
+
+### SMS-notificaties
+Verstuur factuurlinks via sms:
+- Ideaal voor urgente betalingen
+- Hogere openratio dan e-mail
+- Vermeld bedrag en vervaldatum
+- Perfect voor mobile-first klanten
+
+## Internationale aandachtspunten
+
+Facturen wereldwijd verzenden:
+
+<CardGroup cols={2}>
+  <Card title="Tijdzones" icon="globe">
+    - Plan verzending tijdens kantooruren van de klant
+    - Houd rekening met afwijkende werkdagen
+    - Denk aan culturele feestdagen
+    - Toon vervaldatums in de tijdzone van de klant
+  </Card>
+  <Card title="Taal & valuta" icon="language">
+    - Meertalige factuursjablonen
+    - Weergave in lokale valuta
+    - Regiospecifieke betaalmethoden
+    - Voldoen aan lokale regelgeving
+  </Card>
+</CardGroup>
+
+## Best practices
+
+### Kies het juiste verzendmoment
+<Tip>
+  Verstuur facturen direct na oplevering om de vaart erin te houden en je cashflow te verbeteren.
+</Tip>
+
+- **Dienstverleners**: Verstuur binnen 24 uur na afronding
+- **Productverkopen**: Verstuur direct na verzending
+- **Terugkerende facturatie**: Verstuur 3-5 dagen voor de vervaldatum
+- **Projectmijlpalen**: Verstuur bij oplevering van de mijlpaal
+
+### Professioneel communiceren
+- Gebruik duidelijke, professionele onderwerpregels
+- Vermeld alle nodige betaalinformatie
+- Houd de toon vriendelijk en professioneel
+- Voeg altijd je contactinformatie toe
+- Bedank klanten voor hun opdracht
+
+### Veelgemaakte fouten voorkomen
+<Warning>
+  Controleer klant-e-mailadressen en bedragen vóór verzending om vertragingen te voorkomen.
+</Warning>
+
+- Controleer contactgegevens van de klant
+- Herbekijk factuurbedragen en btw
+- Neem duidelijke betaalinstructies op
+- Stel haalbare vervaldatums in
+- Volg consequent op zonder te pushen
+
+## Problemen met verzending oplossen
+
+### E-mailproblemen
+Veelvoorkomende issues en oplossingen:
+
+<AccordionGroup>
+  <Accordion title="Bounces" icon="exclamation-triangle">
+    - Controleer de spelling van het e-mailadres
+    - Let op typefouten in domeinnamen
+    - Gebruik alternatieve contactkanalen
+    - Werk klantgegevens bij
+  </Accordion>
+  <Accordion title="Spamfilters" icon="filter">
+    - Gebruik professionele inhoud
+    - Vermijd spamgevoelige woorden
+    - Voeg een afmeldoptie toe
+    - Authenticeer je domein
+  </Accordion>
+</AccordionGroup>
+
+## Volgende stappen
+
+<CardGroup cols={2}>
+  <Card
+    title="Betalingen volgen"
+    icon="chart-line"
+    href="/nl/essentials/tracking-payments"
+  >
+    Volg factuurstatus en betalingsvoortgang
+  </Card>
+  <Card
+    title="Klantenbeheer"
+    icon="users"
+    href="/nl/essentials/customer-management"
+  >
+    Organiseer klantinformatie en communicatie
+  </Card>
+  <Card
+    title="Betaalmethoden"
+    icon="credit-card"
+    href="/nl/essentials/payment-methods"
+  >
+    Lees meer over beschikbare betaalopties
+  </Card>
+  <Card
+    title="Rapportages"
+    icon="chart-bar"
+    href="/nl/essentials/reporting"
+  >
+    Analyseer je factuur- en betaalprestaties
+  </Card>
+</CardGroup>

--- a/nl/essentials/tracking-payments.mdx
+++ b/nl/essentials/tracking-payments.mdx
@@ -1,0 +1,341 @@
+---
+title: 'Betalingen monitoren'
+description: 'Houd factuurstatus en betalingsvoortgang bij'
+---
+
+# Betalingen monitoren
+
+Volg al je facturen en betalingen realtime met de trackingtools van PayRequest. Zie welke facturen zijn verzonden, bekeken en betaald zodat je altijd weet hoe het ervoor staat met openstaande betalingen.
+
+## Overzicht van het betalingsdashboard
+
+Je PayRequest-dashboard geeft een volledig beeld van je betaalactiviteiten:
+
+<CardGroup cols={3}>
+  <Card title="Totaal openstaand" icon="clock">
+    Bekijk in één oogopslag het totale bedrag aan onbetaalde facturen
+  </Card>
+  <Card title="Achterstallige betalingen" icon="exclamation-triangle">
+    Houd facturen bij die voorbij de vervaldatum zijn
+  </Card>
+  <Card title="Recente activiteit" icon="activity">
+    Monitor de laatste factuur- en betalingsupdates
+  </Card>
+</CardGroup>
+
+## Factuurstatus volgen
+
+### Levenscyclus van een factuur
+
+<Steps>
+  <Step title="Concept">
+    Factuur aangemaakt maar nog niet verstuurd
+  </Step>
+  <Step title="Verzonden">
+    Factuur gemaild of gedeeld met de klant
+  </Step>
+  <Step title="Bekeken">
+    Klant heeft de factuur geopend en bekeken
+  </Step>
+  <Step title="Betaald">
+    Betaling succesvol afgerond
+  </Step>
+</Steps>
+
+### Statusindicatoren
+
+Visuele indicatoren helpen je snel de status te herkennen:
+
+<AccordionGroup>
+  <Accordion title="Kleurcodes" icon="palette">
+    - **Grijs**: Conceptfacturen die nog niet zijn verstuurd
+    - **Blauw**: Verzonden en wacht op actie
+    - **Geel**: Bekeken maar nog niet betaald
+    - **Groen**: Betaald en afgerond
+    - **Rood**: Achterstallig en vraagt aandacht
+  </Accordion>
+  <Accordion title="Statusiconen" icon="icons">
+    - **📝** Conceptfactuur
+    - **📧** Via e-mail verzonden
+    - **👁️** Door klant bekeken
+    - **💳** Betaling in verwerking
+    - **✅** Betaald en afgerond
+    - **⚠️** Achterstallige betaling
+  </Accordion>
+</AccordionGroup>
+
+## Realtime meldingen
+
+Blijf op de hoogte met directe notificaties:
+
+### Soorten meldingen
+
+<Tabs>
+  <Tab title="E-mailmeldingen">
+    Ontvang een e-mail wanneer:
+    - Een klant de factuur bekijkt
+    - Een betaling is afgerond
+    - Een betaling mislukt of wordt geweigerd
+    - Een factuur achterstallig raakt
+    - Een klant wijzigingen aanvraagt
+  </Tab>
+  <Tab title="SMS-meldingen">
+    Ontvang sms'jes voor:
+    - Hoge bedragen die zijn betaald
+    - Dringende achterstallige meldingen
+    - Mislukte betalingspogingen
+    - Bevestigingen van klantbetalingen
+  </Tab>
+  <Tab title="Dashboardmeldingen">
+    Zie alles terug in je dashboard:
+    - Realtime activiteitenfeed
+    - Updates van betaalstatussen
+    - Tijdlijn van klantinteracties
+    - Systeemwaarschuwingen
+  </Tab>
+</Tabs>
+
+### Meldingsinstellingen
+Stel in welke meldingen je wilt ontvangen:
+
+1. Ga naar **Instellingen > Meldingen**
+2. Kies meldingskanalen (e-mail, sms, dashboard)
+3. Selecteer de gebeurtenissen waarvoor je meldingen wilt
+4. Stel rustige uren in voor niet-dringende meldingen
+
+## Betaalanalyse
+
+### Belangrijkste prestatie-indicatoren
+
+<CardGroup cols={2}>
+  <Card title="Betalingssnelheid" icon="stopwatch">
+    - Gemiddelde tijd tot betaling
+    - Snelst betalende klanten
+    - Seizoensgebonden patronen
+    - Benchmarks per branche
+  </Card>
+  <Card title="Succesratio's" icon="chart-line">
+    - Percentage afgeronde betalingen
+    - Analyse van mislukte betalingen
+    - Voorkeuren van klanten
+    - Conversie van bekijken naar betalen
+  </Card>
+</CardGroup>
+
+### Financiële rapporten
+
+Maak gedetailleerde rapporten van je betaalprestaties:
+
+<AccordionGroup>
+  <Accordion title="Cashflow-rapporten" icon="chart-area">
+    - Dagelijkse, wekelijkse en maandelijkse cashflow
+    - Verwachte inkomsten uit openstaande facturen
+    - Seizoenspatronen en trends
+    - Groei vergelijken over perioden
+  </Accordion>
+  <Accordion title="Verouderingsrapporten" icon="calendar-days">
+    - Leeftijd van openstaande facturen
+    - Betaalgedrag per klant
+    - Effectiviteit van incasso
+    - Risico-inschatting
+  </Accordion>
+  <Accordion title="Klantrapporten" icon="users">
+    - Topklanten op basis van betalingen
+    - Gemiddelde betaalsnelheid
+    - Populaire betaalmethoden
+    - Customer lifetime value
+  </Accordion>
+</AccordionGroup>
+
+## Achterstallige facturen beheren
+
+### Achterstallige betalingen identificeren
+
+Herken snel facturen die actie nodig hebben:
+
+- **Achterstallig filter**: Bekijk alle facturen na vervaldatum
+- **Leeftijdscategorieën**: Sorteer op 1-30, 31-60, 60+ dagen achterstallig
+- **Risicoscores per klant**: Identificeer vaak te late betalers
+- **Prioriteitenlijst**: Focus op achterstallige facturen met hoge waarde
+
+### Automatische opvolging
+
+Stel automatische herinneringen in:
+
+<Steps>
+  <Step title="Herinneringen vóór vervaldatum">
+    Verstuur 3-5 dagen voor de vervaldatum een vriendelijke reminder
+  </Step>
+  <Step title="Melding op vervaldatum">
+    Informeer klanten op de vervaldag zelf
+  </Step>
+  <Step title="Opschalen bij achterstand">
+    Verhoog de urgentie bij elke opvolging
+  </Step>
+  <Step title="Laatste waarschuwingen">
+    Verstuur finale verzoeken voordat je verdere stappen neemt
+  </Step>
+</Steps>
+
+## Betaalgedrag van klanten
+
+### Betaalpatronen
+Krijg inzicht in betaalgedrag:
+
+<CardGroup cols={2}>
+  <Card title="Betaaltiming" icon="clock">
+    - Wanneer klanten meestal betalen
+    - Reactie op herinneringsmails
+    - Seizoensgebonden verschillen
+    - Voorkeur voor betaalmethoden
+  </Card>
+  <Card title="Communicatievoorkeuren" icon="message-circle">
+    - Effectiviteit van e-mail versus sms
+    - Beste momenten om herinneringen te sturen
+    - Respons per klanttype
+    - Voorkeurscommunicatiekanaal
+  </Card>
+</CardGroup>
+
+### Klantinzicht
+Volg het betaalgedrag per klant:
+
+- **Betalingshistorie**: Volledige tijdlijn
+- **Gemiddelde betalingstijd**: Hoe snel betalen ze meestal
+- **Voorkeursmethoden**: Creditcard, bankoverschrijving, enz.
+- **Reactie op communicatie**: Hoe reageren ze op reminders
+- **Risiconiveau**: Kans op late of gemiste betalingen
+
+## Prestaties van betaalmethoden
+
+### Betaalmethoden analyseren
+
+<Tabs>
+  <Tab title="Succesratio's">
+    Vergelijk de prestaties van methoden:
+    - Succespercentage van creditcards
+    - Resultaten van bankoverschrijvingen
+    - Gebruik van digitale wallets
+    - Analyse van mislukte betalingen per methode
+  </Tab>
+  <Tab title="Voorkeuren van klanten">
+    Begrijp wat klanten kiezen:
+    - Populairste betaalmethoden
+    - Regionale voorkeuren
+    - Verschillen per leeftijdsgroep
+    - Verschil tussen zakelijke en particuliere klanten
+  </Tab>
+</Tabs>
+
+## Export en integraties
+
+### Data-exportopties
+Exporteer betaaldata voor externe analyse:
+
+<AccordionGroup>
+  <Accordion title="CSV-export" icon="file-csv">
+    - Factuuroverzichten
+    - Betalingstransacties
+    - Klantinformatie
+    - Eigen datumbereiken
+  </Accordion>
+  <Accordion title="Boekhoudintegraties" icon="calculator">
+    - Synchronisatie met QuickBooks
+    - Export naar Xero
+    - Aangepaste boekhoudformaten
+    - Voorbereiding op belastingrapportages
+  </Accordion>
+</AccordionGroup>
+
+### API-toegang
+Voor geavanceerde tracking en integratie:
+- Realtime webhookmeldingen
+- Eigen dashboards bouwen
+- Automatische rapportages
+- Integratie met externe tools
+
+## Mobiel monitoren
+
+### Mobiele app-functies
+Volg betalingen onderweg:
+
+- **Pushmeldingen**: Directe alerts bij betalingen
+- **Snel overzicht**: Dashboard op mobiel
+- **Klantcommunicatie**: Reageer snel op vragen
+- **Factuurbeheer**: Maak en verstuur facturen waar je ook bent
+
+## Best practices voor betaalmonitoring
+
+### Dagelijkse controle
+<Tip>
+  Controleer dagelijks je betalingsdashboard om je cashflow te bewaken en problemen vroeg te signaleren.
+</Tip>
+
+- Bekijk nachtelijke betalingsactiviteit
+- Controleer mislukte betalingen die actie vereisen
+- Houd groei van achterstallige facturen in de gaten
+- Beantwoord vragen van klanten
+
+### Wekelijkse analyse
+- Analyseer trends en patronen
+- Bekijk betaalgedrag per klant
+- Pas opvolgstrategieën aan
+- Plan cashflow op basis van openstaande betalingen
+
+### Maandelijkse evaluatie
+- Genereer uitgebreide rapporten
+- Evalueer incassoresultaten
+- Pas betalingsvoorwaarden aan indien nodig
+- Plan groei op basis van betalingsdata
+
+## Problemen oplossen
+
+### Veelvoorkomende betalingsproblemen
+
+<AccordionGroup>
+  <Accordion title="Mislukte betalingen" icon="x-circle">
+    - Onvoldoende saldo
+    - Verlopen kaarten
+    - Bankweigeringen
+    - Technische issues
+  </Accordion>
+  <Accordion title="Betwistingen" icon="gavel">
+    - Afhandeling van chargebacks
+    - Geschillen met klanten
+    - Fraudepreventie
+    - Stappenplan voor oplossing
+  </Accordion>
+</AccordionGroup>
+
+## Volgende stappen
+
+<CardGroup cols={2}>
+  <Card
+    title="Klantenbeheer"
+    icon="users"
+    href="/nl/essentials/customer-management"
+  >
+    Organiseer en beheer klantrelaties
+  </Card>
+  <Card
+    title="Rapportages"
+    icon="chart-bar"
+    href="/nl/essentials/reporting"
+  >
+    Maak gedetailleerde financiële rapporten
+  </Card>
+  <Card
+    title="Betaalmethoden"
+    icon="credit-card"
+    href="/nl/essentials/payment-methods"
+  >
+    Ontdek beschikbare betaalopties
+  </Card>
+  <Card
+    title="Factuursjablonen"
+    icon="template"
+    href="/nl/essentials/invoice-templates"
+  >
+    Versnel facturatie met sjablonen
+  </Card>
+</CardGroup>

--- a/nl/essentials/webhooks.mdx
+++ b/nl/essentials/webhooks.mdx
@@ -1,0 +1,514 @@
+---
+title: 'Webhooks'
+description: 'Ontvang realtime meldingen over betaalgebeurtenissen'
+---
+
+# Webhooks
+
+Met webhooks ontvangt je applicatie realtime meldingen wanneer er gebeurtenissen plaatsvinden in je PayRequest-account. In plaats van de API continu te pollen verstuurt PayRequest HTTP POST-verzoeken naar jouw endpoint zodra er iets gebeurt.
+
+## Hoe webhooks werken
+
+<Steps>
+  <Step title="Gebeurtenis vindt plaats">
+    Er gebeurt iets in je PayRequest-account (bijv. een betaling wordt voltooid)
+  </Step>
+  <Step title="PayRequest stuurt verzoek">
+    PayRequest verstuurt een HTTP POST-verzoek naar je webhook-endpoint
+  </Step>
+  <Step title="Jouw app verwerkt">
+    Je applicatie ontvangt en verwerkt de webhook-payload
+  </Step>
+  <Step title="Retourneer 200-response">
+    Je endpoint stuurt een statuscode 200 terug als ontvangstbevestiging
+  </Step>
+</Steps>
+
+## Webhooks instellen
+
+### 1. Maak een webhook-endpoint
+
+Maak in je applicatie een endpoint om webhookmeldingen te ontvangen:
+
+<CodeGroup>
+```javascript Express.js
+const express = require('express');
+const app = express();
+
+// Middleware om de ruwe body vast te leggen
+app.use('/webhook', express.raw({ type: 'application/json' }));
+
+app.post('/webhook', (req, res) => {
+  const event = JSON.parse(req.body);
+
+  // Verwerk de gebeurtenis
+  console.log('Ontvangen event:', event.type);
+
+  // Stuur 200 terug als bevestiging
+  res.status(200).send('OK');
+});
+```
+
+```python Flask
+from flask import Flask, request, jsonify
+import json
+
+app = Flask(__name__)
+
+@app.route('/webhook', methods=['POST'])
+def handle_webhook():
+    event = request.get_json()
+
+    # Verwerk de gebeurtenis
+    print(f"Ontvangen event: {event['type']}")
+
+    # Stuur 200 terug als bevestiging
+    return 'OK', 200
+```
+
+```php PHP
+<?php
+// webhook.php
+$payload = file_get_contents('php://input');
+$event = json_decode($payload, true);
+
+// Verwerk de gebeurtenis
+error_log("Ontvangen event: " . $event['type']);
+
+// Stuur 200 terug als bevestiging
+http_response_code(200);
+echo 'OK';
+?>
+```
+
+```ruby Rails
+class WebhooksController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def payrequest
+    event = JSON.parse(request.body.read)
+
+    # Verwerk de gebeurtenis
+    Rails.logger.info "Ontvangen event: #{event['type']}"
+
+    # Stuur 200 terug als bevestiging
+    head :ok
+  end
+end
+```
+</CodeGroup>
+
+### 2. Registreer je webhook
+
+Registreer je endpoint via het dashboard of de API:
+
+<Tabs>
+  <Tab title="Dashboard">
+    1. Ga in het dashboard naar **Instellingen > Webhooks**
+    2. Klik op **Webhook-endpoint toevoegen**
+    3. Vul je endpoint-URL in (in productie verplicht HTTPS)
+    4. Selecteer de events die je wilt ontvangen
+    5. Klik op **Webhook aanmaken**
+  </Tab>
+
+  <Tab title="API">
+    ```bash
+    curl -X POST https://api.payrequest.io/v1/webhooks \
+      -H "Authorization: Bearer your_api_key" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "url": "https://jouwsite.com/webhook",
+        "events": ["payment.completed", "payment.failed"]
+      }'
+    ```
+  </Tab>
+</Tabs>
+
+## Webhook-events
+
+PayRequest verstuurt webhooks voor diverse gebeurtenissen. Dit zijn de meest gebruikte:
+
+<AccordionGroup>
+  <Accordion title="payment.created" icon="plus">
+    Wordt verstuurd wanneer een nieuw betaalverzoek is aangemaakt.
+
+    ```json
+    {
+      "type": "payment.created",
+      "data": {
+        "id": "pay_1234567890",
+        "amount": 2500,
+        "currency": "USD",
+        "status": "pending",
+        "created_at": "2024-01-15T10:30:00Z"
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="payment.completed" icon="check">
+    Wordt verstuurd wanneer een betaling succesvol is afgerond.
+
+    ```json
+    {
+      "type": "payment.completed",
+      "data": {
+        "id": "pay_1234567890",
+        "amount": 2500,
+        "currency": "USD",
+        "status": "completed",
+        "completed_at": "2024-01-15T10:35:00Z"
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="payment.failed" icon="x">
+    Wordt verstuurd wanneer een betalingspoging mislukt.
+
+    ```json
+    {
+      "type": "payment.failed",
+      "data": {
+        "id": "pay_1234567890",
+        "amount": 2500,
+        "currency": "USD",
+        "status": "failed",
+        "failure_reason": "insufficient_funds"
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="payment.cancelled" icon="ban">
+    Wordt verstuurd wanneer een betaling is geannuleerd.
+
+    ```json
+    {
+      "type": "payment.cancelled",
+      "data": {
+        "id": "pay_1234567890",
+        "amount": 2500,
+        "currency": "USD",
+        "status": "cancelled",
+        "cancelled_at": "2024-01-15T10:32:00Z"
+      }
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Veiligheid van webhooks
+
+### Webhook-handtekeningen verifiëren
+
+PayRequest ondertekent elke webhook met een geheim. Controleer altijd de handtekening om te verzekeren dat het verzoek echt van PayRequest komt:
+
+<CodeGroup>
+```javascript Node.js
+const crypto = require('crypto');
+
+function verifyWebhookSignature(payload, signature, secret) {
+  const expectedSignature = crypto
+    .createHmac('sha256', secret)
+    .update(payload, 'utf8')
+    .digest('hex');
+
+  return signature === `sha256=${expectedSignature}`;
+}
+
+app.post('/webhook', (req, res) => {
+  const signature = req.headers['payrequest-signature'];
+  const payload = req.body;
+
+  if (!verifyWebhookSignature(payload, signature, webhookSecret)) {
+    return res.status(401).send('Invalid signature');
+  }
+
+  // Verwerk de webhook...
+  res.status(200).send('OK');
+});
+```
+
+```python Python
+import hmac
+import hashlib
+
+def verify_webhook_signature(payload, signature, secret):
+    expected_signature = hmac.new(
+        secret.encode('utf-8'),
+        payload.encode('utf-8'),
+        hashlib.sha256
+    ).hexdigest()
+
+    return signature == f"sha256={expected_signature}"
+
+@app.route('/webhook', methods=['POST'])
+def handle_webhook():
+    signature = request.headers.get('payrequest-signature')
+    payload = request.get_data(as_text=True)
+
+    if not verify_webhook_signature(payload, signature, webhook_secret):
+        return 'Invalid signature', 401
+
+    # Verwerk de webhook...
+    return 'OK', 200
+```
+</CodeGroup>
+
+### Best practices
+
+<Warning>
+  **Controleer webhook-handtekeningen altijd** om te voorkomen dat kwaadwillende verzoeken je applicatie bereiken.
+</Warning>
+
+- **Gebruik HTTPS**: Accepteer in productie alleen webhooks via HTTPS
+- **Verifieer handtekeningen**: Valideer elke webhook-handtekening
+- **Idempotent verwerken**: Ga netjes om met dubbele webhooks
+- **Snel antwoorden**: Stuur snel een 200 terug en verwerk zware taken asynchroon
+- **Timeouts**: PayRequest stopt na 30 seconden wachten
+
+## Webhook-events verwerken
+
+### Verwerkingspatroon
+
+<CodeGroup>
+```javascript Node.js
+app.post('/webhook', (req, res) => {
+  const event = JSON.parse(req.body);
+
+  // Bevestig direct ontvangst
+  res.status(200).send('OK');
+
+  // Verwerk het event asynchroon
+  processEventAsync(event);
+});
+
+async function processEventAsync(event) {
+  try {
+    switch (event.type) {
+      case 'payment.completed':
+        await fulfillOrder(event.data);
+        await sendConfirmationEmail(event.data);
+        break;
+
+      case 'payment.failed':
+        await handleFailedPayment(event.data);
+        break;
+
+      default:
+        console.log(`Onbekend eventtype: ${event.type}`);
+    }
+  } catch (error) {
+    console.error('Fout bij verwerken webhook:', error);
+    // Voeg eventueel toe aan een retry-queue
+  }
+}
+```
+
+```python Python
+from celery import Celery
+
+app = Celery('webhook_processor')
+
+@app.route('/webhook', methods=['POST'])
+def handle_webhook():
+    event = request.get_json()
+
+    # Bevestig ontvangst direct
+    # Verwerk event asynchroon
+    process_event_async.delay(event)
+
+    return 'OK', 200
+
+@app.task
+def process_event_async(event):
+    try:
+        if event['type'] == 'payment.completed':
+            fulfill_order(event['data'])
+            send_confirmation_email(event['data'])
+        elif event['type'] == 'payment.failed':
+            handle_failed_payment(event['data'])
+    except Exception as e:
+        print(f"Fout bij verwerken webhook: {e}")
+        # Voeg eventueel toe aan een retry-queue
+```
+</CodeGroup>
+
+### Idempotentie
+
+Verwerk dubbele webhooks probleemloos door idempotent te werken:
+
+```javascript
+const processedEvents = new Set();
+
+app.post('/webhook', (req, res) => {
+  const event = JSON.parse(req.body);
+  const eventId = event.id;
+
+  // Controleren of het event al is verwerkt
+  if (processedEvents.has(eventId)) {
+    return res.status(200).send('Already processed');
+  }
+
+  // Verwerk het event
+  processEvent(event);
+
+  // Markeer als verwerkt
+  processedEvents.add(eventId);
+
+  res.status(200).send('OK');
+});
+```
+
+## Webhooks testen
+
+### Lokale ontwikkeling
+
+Gebruik tools zoals ngrok om je lokale server publiek te maken voor tests:
+
+```bash
+# Installeer ngrok
+npm install -g ngrok
+
+# Stel je lokale server bloot
+ngrok http 3000
+
+# Gebruik de gegenereerde URL in je webhook-instellingen
+# https://abc123.ngrok.io/webhook
+```
+
+### Webhook-testtool
+
+PayRequest biedt in het dashboard een webhook-testtool:
+
+1. Ga naar **Instellingen > Webhooks**
+2. Klik op **Webhook testen** naast je endpoint
+3. Kies een eventtype en verstuur een testpayload
+4. Bekijk de respons en los eventuele fouten op
+
+### Voorbeeld-testevents
+
+<AccordionGroup>
+  <Accordion title="Test payment completed">
+    ```json
+    {
+      "id": "evt_test_12345",
+      "type": "payment.completed",
+      "created_at": "2024-01-15T10:30:00Z",
+      "data": {
+        "id": "pay_test_12345",
+        "amount": 2500,
+        "currency": "USD",
+        "status": "completed",
+        "description": "Test payment",
+        "metadata": {
+          "order_id": "test_order_123"
+        }
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="Test payment failed">
+    ```json
+    {
+      "id": "evt_test_67890",
+      "type": "payment.failed",
+      "created_at": "2024-01-15T10:30:00Z",
+      "data": {
+        "id": "pay_test_67890",
+        "amount": 1000,
+        "currency": "USD",
+        "status": "failed",
+        "failure_reason": "card_declined",
+        "failure_message": "Your card was declined."
+      }
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Probleemoplossing
+
+### Veelvoorkomende issues
+
+<AccordionGroup>
+  <Accordion title="Webhook komt niet aan" icon="exclamation-triangle">
+    **Mogelijke oorzaken:**
+    - Endpoint-URL is onjuist of onbereikbaar
+    - Firewall blokkeert inkomende verzoeken
+    - Server retourneert geen statuscode 200
+
+    **Oplossingen:**
+    - Controleer of je endpoint bereikbaar is
+    - Check firewall-instellingen
+    - Zorg dat je endpoint een 200-status terugstuurt
+  </Accordion>
+
+  <Accordion title="Handtekeningverificatie faalt" icon="key">
+    **Mogelijke oorzaken:**
+    - Verkeerde webhook-secret
+    - Middleware past de body aan
+    - Onjuiste berekening van de handtekening
+
+    **Oplossingen:**
+    - Controleer het geheim in het dashboard
+    - Lees de ruwe request-body uit
+    - Controleer je logica voor het berekenen van de handtekening
+  </Accordion>
+
+  <Accordion title="Dubbele events" icon="copy">
+    **Mogelijke oorzaken:**
+    - Netwerktime-outs
+    - Server stuurt geen 200-status
+    - Retry-mechanisme van PayRequest
+
+    **Oplossingen:**
+    - Implementeer idempotentiecontrole
+    - Stuur snel een 200-respons terug
+    - Verwerk dubbele events netjes
+  </Accordion>
+</AccordionGroup>
+
+### Debugtools
+
+Volg de levering van webhooks in je dashboard:
+
+- **Delivery Attempts**: Bekijk alle afleverpogingen
+- **Response Codes**: Zie welke HTTP-statuscodes zijn teruggestuurd
+- **Payload Inspector**: Bekijk de exacte payload
+- **Retry Schedule**: Begrijp wanneer mislukte webhooks opnieuw worden geprobeerd
+
+## Volgende stappen
+
+<CardGroup cols={2}>
+  <Card
+    title="API-referentie"
+    icon="code"
+    href="/api-reference/webhooks"
+  >
+    Beheer webhooks via de API
+  </Card>
+  <Card
+    title="Beveiligingsgids"
+    icon="shield"
+    href="/nl/essentials/security"
+  >
+    Beveilig je webhook-endpoints
+  </Card>
+  <Card
+    title="Fouthandling"
+    icon="triangle-exclamation"
+    href="/essentials/errors"
+  >
+    Ga netjes om met webhookfouten
+  </Card>
+  <Card
+    title="Testgids"
+    icon="flask"
+    href="/essentials/testing"
+  >
+    Test je webhookintegratie grondig
+  </Card>
+</CardGroup>

--- a/nl/introduction.mdx
+++ b/nl/introduction.mdx
@@ -1,0 +1,100 @@
+---
+title: Introductie
+description: 'Welkom bij PayRequest - het moderne betaalplatform voor bedrijven'
+---
+
+# Welkom bij PayRequest
+
+PayRequest is een compleet betaalplatform waarmee bedrijven professionele facturen kunnen maken, online betalingen kunnen innen en hun financiële workflows eenvoudig kunnen beheren. Ons platform biedt intuïtieve tools en soepele processen zodat jij sneller betaald krijgt.
+
+## Wat is PayRequest?
+
+PayRequest vereenvoudigt het innen van betalingen door het volgende te bieden:
+
+- **Professionele facturen**: Maak en verstuur fraaie, gepersonaliseerde facturen naar je klanten
+- **Betaallinks**: Genereer veilige betaallinks die je kunt delen via e-mail, sms of kunt insluiten in je applicaties
+- **Betaalverzoeken**: Verstuur betaalverzoeken naar klanten met geautomatiseerde opvolging en herinneringen
+- **Online checkout**: Bied je klanten een naadloze betaalervaring
+- **Meerdere betaalmethoden**: Ondersteuning voor creditcards, bankoverschrijvingen, digitale wallets en lokale betaalmethoden
+
+## Aan de slag
+
+<CardGroup cols={2}>
+  <Card
+    title="Maak je eerste factuur"
+    icon="file-invoice"
+    href="/nl/quickstart"
+  >
+    Leer hoe je professionele facturen opstelt en verzendt
+  </Card>
+  <Card
+    title="Factuurbeheer"
+    icon="tasks"
+    href="/nl/essentials/creating-invoices"
+  >
+    Beheer facturen, betalingen en klantrelaties
+  </Card>
+  <Card
+    title="Dashboard inloggen"
+    icon="chart-line"
+    href="https://dashboard.payrequest.io"
+  >
+    Open je PayRequest-dashboard
+  </Card>
+  <Card
+    title="Support"
+    icon="life-ring"
+    href="mailto:support@payrequest.io"
+  >
+    Krijg hulp van ons supportteam
+  </Card>
+</CardGroup>
+
+## Belangrijkste functies
+
+<CardGroup cols={3}>
+  <Card
+    title="Snel facturen maken"
+    icon="file-plus"
+  >
+    Maak in enkele minuten professionele facturen met onze intuïtieve factuurbouwer
+  </Card>
+  <Card
+    title="Wereldwijd betalen"
+    icon="globe"
+  >
+    Accepteer betalingen van klanten wereldwijd met ondersteuning voor meerdere valuta en betaalmethoden
+  </Card>
+  <Card
+    title="Realtime meldingen"
+    icon="bell"
+  >
+    Blijf op de hoogte met directe meldingen zodra facturen bekeken of betaald worden
+  </Card>
+  <Card
+    title="Veilig & compliant"
+    icon="shield-check"
+  >
+    PCI DSS-conforme infrastructuur met geavanceerde fraudepreventie
+  </Card>
+  <Card
+    title="Analyse & rapportage"
+    icon="chart-bar"
+  >
+    Uitgebreide rapportages en analyses om je betaalprestaties te volgen
+  </Card>
+  <Card
+    title="Eigen branding"
+    icon="paintbrush"
+  >
+    Pas facturen en betaalpagina's aan met je eigen huisstijl
+  </Card>
+</CardGroup>
+
+## Veelgebruikte scenario's
+
+- **Freelancers & bureaus**: Verstuur professionele facturen en betaalverzoeken naar klanten
+- **Mkb-bedrijven**: Optimaliseer je facturatieprocessen en verbeter je cashflow
+- **Dienstverleners**: Factureer consults, diensten en projectwerk
+- **E-commerce**: Verstuur betaalverzoeken voor maatwerkbestellingen en services
+- **Eventmanagement**: Innen van betalingen voor evenementen en registratiekosten

--- a/nl/quickstart.mdx
+++ b/nl/quickstart.mdx
@@ -1,0 +1,159 @@
+---
+title: 'Snelstart'
+description: 'Ga binnen vijf minuten met PayRequest aan de slag'
+---
+
+# Snelstartgids
+
+Ga direct met PayRequest aan de slag en maak in een paar stappen je eerste factuur. Deze gids helpt je bij het instellen van je account en het versturen van je eerste professionele factuur.
+
+## Stap 1: Maak je account aan
+
+<Steps>
+  <Step title="Registreer je bij PayRequest">
+    Bezoek [dashboard.payrequest.io](https://dashboard.payrequest.io) en maak gratis een account aan. Je krijgt meteen toegang om facturen te maken en te verzenden.
+  </Step>
+  <Step title="Stel je bedrijfsprofiel in">
+    Ga in het dashboard naar **Instellingen > Bedrijfsprofiel** om je bedrijfsgegevens, logo en betaalgegevens toe te voegen.
+  </Step>
+  <Step title="Kies hoe je betaald wilt worden">
+    Stel je gewenste betaalmethoden en bankrekening in waarop je betalingen wilt ontvangen:
+    - **Bankoverschrijving** - Directe uitbetalingen naar je bankrekening
+    - **Creditcards** - Accepteer Visa, MasterCard en andere grote kaarten
+    - **Digitale wallets** - PayPal, Apple Pay, Google Pay en meer
+  </Step>
+</Steps>
+
+## Stap 2: Maak je eerste factuur
+
+<Tabs>
+  <Tab title="Factuur maken in het dashboard">
+    De eenvoudigste manier om professionele facturen op te stellen:
+
+    1. Ga in je dashboard naar **Facturen > Factuur maken**
+    2. Vul de factuurgegevens in:
+       - **Klantinformatie**: Naam, e-mail en factuuradres
+       - **Factuurregels**: Beschrijving, aantal en prijs per product/dienst
+       - **Betaalvoorwaarden**: Vervaldatum en betaalinstructies
+       - **Branding**: Voeg je logo toe en pas kleuren aan
+    3. Bekijk een voorbeeld van je factuur om te controleren of alles klopt
+    4. Klik op **Factuur verzenden** om deze rechtstreeks naar je klant te mailen
+
+    Je klant ontvangt een fraai opgemaakte factuur met een veilige betaallink waarmee direct betaald kan worden.
+  </Tab>
+
+  <Tab title="Snelle betaallink">
+    Voor eenvoudige eenmalige betalingen:
+
+    1. Ga in je dashboard naar **Betalingen > Betaallink maken**
+    2. Vul de betalingsgegevens in (bedrag, beschrijving, e-mailadres ontvanger)
+    3. Klik op **Betaallink maken**
+    4. Deel de gegenereerde link met je klant
+
+    ```
+    https://payrequest.io/p/jouw-betalings-id
+    ```
+
+    Je klant kan met deze link direct betalen en jij ontvangt realtime meldingen.
+  </Tab>
+
+  <Tab title="Terugkerende facturen">
+    Voor abonnementen of terugkerende betalingen:
+
+    1. Maak een factuur zoals hierboven beschreven
+    2. Schakel in de factuurinstellingen **Terugkerende factuur** in
+    3. Stel de factuurfrequentie in (wekelijks, maandelijks, per kwartaal, jaarlijks)
+    4. Configureer automatisch verzenden en betalingsverwerking
+    5. Sla de sjabloon voor de terugkerende factuur op
+
+    PayRequest genereert en verzendt automatisch facturen volgens jouw planning en verwerkt betalingen zodra klanten betalen.
+  </Tab>
+</Tabs>
+
+## Stap 3: Volg betalingen en beheer klanten
+
+Houd zicht op je facturen en betalingen:
+
+<CardGroup cols={2}>
+  <Card title="Betalingen volgen" icon="chart-line">
+    Monitor de status van facturen in realtime:
+    - **Verzonden**: De factuur is gemaild naar de klant
+    - **Bekeken**: De klant heeft de factuur geopend
+    - **Betaald**: De betaling is afgerond
+    - **Achterstallig**: De factuur is over de vervaldatum
+  </Card>
+  <Card title="Klantenbeheer" icon="users">
+    Bouw en onderhoud je klantenbestand:
+    - Sla klantcontactgegevens op
+    - Volg betalingsgeschiedenis en voorkeuren
+    - Stel automatische betalingsherinneringen in
+    - Exporteer klantgegevens voor de boekhouding
+  </Card>
+</CardGroup>
+
+### Betaalmeldingen
+
+Je ontvangt direct meldingen wanneer:
+- Een klant je factuur bekijkt
+- Een betaling is voltooid
+- Een factuur achterstallig wordt
+- Een betaling mislukt of wordt betwist
+
+Pas meldingen aan via **Instellingen > Meldingen** en kies hoe je bericht wilt worden (e-mail, sms of alleen dashboard).
+
+## Stap 4: Optimaliseer je facturatieproces
+
+<Steps>
+  <Step title="Maak factuursjablonen">
+    Bespaar tijd door herbruikbare sjablonen te maken voor veelvoorkomende diensten of producten.
+  </Step>
+  <Step title="Stel automatische herinneringen in">
+    Laat PayRequest automatisch betalingsherinneringen versturen voor achterstallige facturen.
+  </Step>
+  <Step title="Pas je branding aan">
+    Upload je logo en pas kleuren aan zodat facturen aansluiten bij je huisstijl.
+  </Step>
+  <Step title="Exporteer voor de boekhouding">
+    Exporteer je factuur- en betalingsgegevens om te koppelen met je boekhoudsoftware.
+  </Step>
+</Steps>
+
+## Volgende stappen
+
+<CardGroup cols={2}>
+  <Card
+    title="Factuursjablonen"
+    icon="file-invoice"
+    href="/nl/essentials/creating-invoices"
+  >
+    Leer hoe je factuursjablonen maakt en beheert
+  </Card>
+  <Card
+    title="Betaalmethoden"
+    icon="credit-card"
+    href="/nl/essentials/payment-methods"
+  >
+    Ontdek de ondersteunde betaalmethoden
+  </Card>
+  <Card
+    title="Klantenbeheer"
+    icon="users"
+    href="/nl/essentials/customer-management"
+  >
+    Organiseer en beheer je klantrelaties
+  </Card>
+  <Card
+    title="Betalingen volgen"
+    icon="chart-bar"
+    href="/nl/essentials/payment-tracking"
+  >
+    Monitor en analyseer je betaalprestaties
+  </Card>
+</CardGroup>
+
+## Hulp nodig?
+
+- **Documentatie**: Bekijk onze uitgebreide gidsen
+- **Support**: Mail ons via [support@payrequest.io](mailto:support@payrequest.io)
+- **Community**: Word lid van onze developercommunity
+- **Status**: Controleer onze systeemsstatus op [status.payrequest.io](https://status.payrequest.io)


### PR DESCRIPTION
## Summary
- add i18n configuration, a Dutch language link, and navigation groups for Nederlands content
- provide Dutch translations for the introduction, quickstart, development, and essential invoicing/payment guides

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1d089f7348322a4425a10d3291a27