### PR TITLE
Add Dutch translations and locale-specific navigation

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -42,86 +42,94 @@
     "name": "Dashboard",
     "url": "https://dashboard.payrequest.io"
   },
-
-  "anchors": [
-    {
-      "name": "Documentation",
-      "icon": "book-open-cover",
-      "url": "https://payrequest.mintlify.app/"
-    }
-  ],
-  "navigation": [
-    {
-      "group": "Get Started",
-      "pages": [
-        "introduction",
-        "quickstart",
-        "development"
-      ]
-    },
-    {
-      "group": "Core Concepts",
-      "pages": [
-        "essentials/payments",
-        "essentials/payment-methods",
-        "essentials/checkout-urls",
-        "essentials/webhooks",
-        "essentials/security"
-      ]
-    },
-    {
-      "group": "Business Workflows",
-      "pages": [
-        "essentials/invoice-templates",
-        "essentials/customer-management",
-        "essentials/payment-tracking",
-        "essentials/reporting"
-      ]
-    },
-    {
-      "group": "Invoice Management",
-      "pages": [
-        "essentials/creating-invoices",
-        "essentials/sending-invoices",
-        "essentials/tracking-payments"
-      ]
-    },
-    {
-      "group": "Aan de slag (NL)",
-      "pages": [
-        "nl/introduction",
-        "nl/quickstart",
-        "nl/development"
-      ]
-    },
-    {
-      "group": "Belangrijkste concepten (NL)",
-      "pages": [
-        "nl/essentials/payments",
-        "nl/essentials/payment-methods",
-        "nl/essentials/checkout-urls",
-        "nl/essentials/webhooks",
-        "nl/essentials/security"
-      ]
-    },
-    {
-      "group": "Zakelijke workflows (NL)",
-      "pages": [
-        "nl/essentials/invoice-templates",
-        "nl/essentials/customer-management",
-        "nl/essentials/payment-tracking",
-        "nl/essentials/reporting"
-      ]
-    },
-    {
-      "group": "Factuurbeheer (NL)",
-      "pages": [
-        "nl/essentials/creating-invoices",
-        "nl/essentials/sending-invoices",
-        "nl/essentials/tracking-payments"
-      ]
-    }
-  ],
+  "navigation": {
+    "en": [
+      {
+        "group": "Get Started",
+        "pages": [
+          "introduction",
+          "quickstart",
+          "development"
+        ]
+      },
+      {
+        "group": "Core Concepts",
+        "pages": [
+          "essentials/payments",
+          "essentials/payment-methods",
+          "essentials/checkout-urls",
+          "essentials/webhooks",
+          "essentials/security"
+        ]
+      },
+      {
+        "group": "Business Workflows",
+        "pages": [
+          "essentials/invoice-templates",
+          "essentials/customer-management",
+          "essentials/payment-tracking",
+          "essentials/reporting"
+        ]
+      },
+      {
+        "group": "Invoice Management",
+        "pages": [
+          "essentials/creating-invoices",
+          "essentials/sending-invoices",
+          "essentials/tracking-payments"
+        ]
+      }
+    ],
+    "nl": [
+      {
+        "group": "Aan de slag",
+        "pages": [
+          "nl/introduction",
+          "nl/quickstart",
+          "nl/development"
+        ]
+      },
+      {
+        "group": "Belangrijkste concepten",
+        "pages": [
+          "nl/essentials/payments",
+          "nl/essentials/payment-methods",
+          "nl/essentials/checkout-urls",
+          "nl/essentials/webhooks",
+          "nl/essentials/security",
+          "nl/essentials/authentication"
+        ]
+      },
+      {
+        "group": "Zakelijke workflows",
+        "pages": [
+          "nl/essentials/invoice-templates",
+          "nl/essentials/customer-management",
+          "nl/essentials/payment-tracking",
+          "nl/essentials/reporting"
+        ]
+      },
+      {
+        "group": "Factuurbeheer",
+        "pages": [
+          "nl/essentials/creating-invoices",
+          "nl/essentials/sending-invoices",
+          "nl/essentials/tracking-payments"
+        ]
+      },
+      {
+        "group": "Documentatiebeheer",
+        "pages": [
+          "nl/essentials/navigation",
+          "nl/essentials/settings",
+          "nl/essentials/markdown",
+          "nl/essentials/code",
+          "nl/essentials/images",
+          "nl/essentials/reusable-snippets"
+        ]
+      }
+    ]
+  },
   "footerSocials": {
     "twitter": "https://twitter.com/payrequest_io"
   }

--- a/nl/essentials/authentication.mdx
+++ b/nl/essentials/authentication.mdx
@@ -1,0 +1,320 @@
+---
+title: 'Authenticatie'
+description: 'Leer hoe je met de PayRequest API authenticeert'
+---
+
+# Authenticatie
+
+De PayRequest API gebruikt API-sleutels voor authenticatie. Alle API-verzoeken moeten een geldige API-sleutel in de request headers bevatten.
+
+## API-sleutels
+
+API-sleutels zijn unieke identifiers waarmee je applicatie zich bij de PayRequest API legitimeert. Je vindt je API-sleutels in het dashboard onder **Instellingen > API-sleutels**.
+
+<Warning>
+  **Houd je API-sleutels geheim!** Publiceer ze nooit in client-side code, openbare repositories of logbestanden. Behandel ze zoals wachtwoorden.
+</Warning>
+
+### Soorten sleutels
+
+PayRequest biedt twee soorten API-sleutels:
+
+<Tabs>
+  <Tab title="Testsleutels">
+    - Gebruik je voor ontwikkeling en testen
+    - Beginnen met `test_`
+    - Verwerken geen echt geld
+    - Veilig te gebruiken in ontwikkelomgevingen
+
+    ```
+    test_1234567890abcdef
+    ```
+  </Tab>
+
+  <Tab title="Livesleutels">
+    - Gebruik je voor productieomgevingen
+    - Beginnen met `live_`
+    - Verwerken echte betalingen
+    - Gebruik je uitsluitend op beveiligde servers
+
+    ```
+    live_1234567890abcdef
+    ```
+  </Tab>
+</Tabs>
+
+## Geauthenticeerde requests maken
+
+Voeg je API-sleutel toe aan de `Authorization`-header met het Bearer-tokenformaat:
+
+<CodeGroup>
+```bash cURL
+curl -X GET https://api.payrequest.io/v1/payments \
+  -H "Authorization: Bearer your_api_key_here" \
+  -H "Content-Type: application/json"
+```
+
+```javascript JavaScript
+const response = await fetch('https://api.payrequest.io/v1/payments', {
+  headers: {
+    'Authorization': 'Bearer your_api_key_here',
+    'Content-Type': 'application/json'
+  }
+});
+```
+
+```python Python
+import requests
+
+headers = {
+    'Authorization': 'Bearer your_api_key_here',
+    'Content-Type': 'application/json'
+}
+
+response = requests.get(
+    'https://api.payrequest.io/v1/payments',
+    headers=headers
+)
+```
+
+```php PHP
+<?php
+$headers = [
+    'Authorization: Bearer your_api_key_here',
+    'Content-Type: application/json'
+];
+
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.payrequest.io/v1/payments');
+curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+$response = curl_exec($ch);
+curl_close($ch);
+?>
+```
+</CodeGroup>
+
+## Authenticatiefouten
+
+Als de authenticatie faalt, ontvang je een `401 Unauthorized`-response:
+
+```json
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "Invalid API key provided"
+  }
+}
+```
+
+Veelvoorkomende authenticatiefouten:
+
+<AccordionGroup>
+  <Accordion title="Ongeldige API-sleutel" icon="key">
+    **Fout**: `unauthorized`
+
+    **Oorzaak**: De API-sleutel is ongeldig, verlopen of verkeerd gespeld.
+
+    **Oplossing**: Controleer je API-sleutel in het dashboard en zorg dat deze correct is geformatteerd.
+  </Accordion>
+
+  <Accordion title="Ontbrekende Authorization-header" icon="header">
+    **Fout**: `missing_authorization`
+
+    **Oorzaak**: De `Authorization`-header ontbreekt in het verzoek.
+
+    **Oplossing**: Voeg de header `Authorization: Bearer your_api_key` toe.
+  </Accordion>
+
+  <Accordion title="Verkeerde omgeving" icon="server">
+    **Fout**: `invalid_environment`
+
+    **Oorzaak**: Een testsleutel gebruiken tegen de live API of andersom.
+
+    **Oplossing**: Gebruik het juiste API-endpoint voor het type sleutel.
+  </Accordion>
+
+  <Accordion title="Ingetrokken sleutel" icon="ban">
+    **Fout**: `key_revoked`
+
+    **Oorzaak**: De API-sleutel is ingetrokken of verwijderd.
+
+    **Oplossing**: Genereer een nieuwe API-sleutel in je dashboard.
+  </Accordion>
+</AccordionGroup>
+
+## Best practices
+
+### Omgevingsvariabelen
+
+Sla API-sleutels op in omgevingsvariabelen in plaats van ze hard te coderen:
+
+<CodeGroup>
+```bash Omgeving
+# .env-bestand
+PAYREQUEST_API_KEY=your_api_key_here
+```
+
+```javascript Node.js
+// Laden vanuit de omgeving
+const apiKey = process.env.PAYREQUEST_API_KEY;
+```
+
+```python Python
+import os
+
+# Laden vanuit de omgeving
+api_key = os.getenv('PAYREQUEST_API_KEY')
+```
+
+```php PHP
+<?php
+// Laden vanuit de omgeving
+$apiKey = getenv('PAYREQUEST_API_KEY');
+?>
+```
+</CodeGroup>
+
+### Sleutelrotatie
+
+Roteer je API-sleutels regelmatig voor extra veiligheid:
+
+<Steps>
+  <Step title="Genereer een nieuwe sleutel">
+    Maak een nieuwe API-sleutel in je dashboard
+  </Step>
+  <Step title="Werk applicaties bij">
+    Zorg dat al je applicaties de nieuwe sleutel gebruiken
+  </Step>
+  <Step title="Test grondig">
+    Controleer of alle integraties met de nieuwe sleutel werken
+  </Step>
+  <Step title="Trek de oude sleutel in">
+    Verwijder de oude sleutel zodra de migratie klaar is
+  </Step>
+</Steps>
+
+### Monitoring
+
+Monitor het gebruik van je API-sleutels in het dashboard:
+
+- **Requestvolume**: Bekijk hoe vaak de API wordt aangeroepen
+- **Foutpercentages**: Houd authenticatiefouten in de gaten
+- **Laatst gebruikt**: Zie wanneer sleutels voor het laatst actief waren
+- **IP-beperkingen**: Beperk sleutels tot specifieke IP-adressen
+
+## Webhook-authenticatie
+
+Webhooks gebruiken een andere authenticatiemethode. PayRequest ondertekent webhook-payloads met een geheime sleutel die je kunt verifiëren:
+
+<CodeGroup>
+```javascript Node.js
+const crypto = require('crypto');
+
+function verifyWebhook(payload, signature, secret) {
+  const expectedSignature = crypto
+    .createHmac('sha256', secret)
+    .update(payload)
+    .digest('hex');
+
+  return signature === `sha256=${expectedSignature}`;
+}
+
+// In je webhook-handler
+const signature = req.headers['payrequest-signature'];
+const isValid = verifyWebhook(req.body, signature, webhookSecret);
+```
+
+```python Python
+import hmac
+import hashlib
+
+def verify_webhook(payload, signature, secret):
+    expected_signature = hmac.new(
+        secret.encode(),
+        payload.encode(),
+        hashlib.sha256
+    ).hexdigest()
+
+    return signature == f"sha256={expected_signature}"
+
+# In je webhook-handler
+signature = request.headers.get('payrequest-signature')
+is_valid = verify_webhook(request.body, signature, webhook_secret)
+```
+</CodeGroup>
+
+## Rate limiting
+
+API-sleutels hebben snelheidslimieten. Als je de limiet overschrijdt, ontvang je een `429 Too Many Requests`-response:
+
+```json
+{
+  "error": {
+    "code": "rate_limit_exceeded",
+    "message": "Too many requests. Try again later."
+  }
+}
+```
+
+Informatie over limieten staat in de response-headers:
+
+```http
+X-RateLimit-Limit: 100
+X-RateLimit-Remaining: 87
+X-RateLimit-Reset: 1640995200
+```
+
+## Authenticatie testen
+
+Gebruik deze endpoint om je API-sleutel te testen:
+
+<CodeGroup>
+```bash Test API-sleutel
+curl -X GET https://api.payrequest.io/v1/account \
+  -H "Authorization: Bearer your_api_key_here"
+```
+
+```json Succesvolle response
+{
+  "id": "acc_1234567890",
+  "email": "user@example.com",
+  "name": "Your Company",
+  "environment": "test"
+}
+```
+</CodeGroup>
+
+## Volgende stappen
+
+<CardGroup cols={2}>
+  <Card
+    title="Maak je eerste betaling"
+    icon="credit-card"
+    href="/nl/essentials/payments"
+  >
+    Start met geauthenticeerde API-calls
+  </Card>
+  <Card
+    title="Webhooks instellen"
+    icon="webhook"
+    href="/nl/essentials/webhooks"
+  >
+    Configureer webhookauthenticatie
+  </Card>
+  <Card
+    title="Veiligheidsrichtlijnen"
+    icon="shield"
+    href="/nl/essentials/security"
+  >
+    Houd je integratie veilig
+  </Card>
+  <Card
+    title="Betalingen monitoren"
+    icon="gauge"
+    href="/nl/essentials/payment-tracking"
+  >
+    Analyseer API-activiteit en prestaties
+  </Card>
+</CardGroup>

--- a/nl/essentials/code.mdx
+++ b/nl/essentials/code.mdx
@@ -1,0 +1,37 @@
+---
+title: 'Codeblokken'
+description: 'Toon inline code en volledige codeblokken'
+icon: 'code'
+---
+
+## Basis
+
+### Inline code
+
+Markeer een `woord` of `zin` als code door deze tussen backticks (`) te plaatsen.
+
+```
+Markeer een `woord` of `zin` als code door deze tussen backticks (`) te plaatsen.
+```
+
+### Codeblok
+
+Gebruik [afgebakende codeblokken](https://www.markdownguide.org/extended-syntax/#fenced-code-blocks) door code tussen drie backticks te zetten. Voeg direct na de openingsbackticks de programmeertaal van je snippet toe voor syntax highlighting. Optioneel kun je na de taal ook nog een bestandsnaam vermelden.
+
+```java HelloWorld.java
+class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Hello, World!");
+    }
+}
+```
+
+````md
+```java HelloWorld.java
+class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Hello, World!");
+    }
+}
+```
+````

--- a/nl/essentials/images.mdx
+++ b/nl/essentials/images.mdx
@@ -1,0 +1,59 @@
+---
+title: 'Afbeeldingen en embeds'
+description: 'Voeg afbeeldingen, video\'s en andere HTML-elementen toe'
+icon: 'image'
+---
+
+<img
+  style={{ borderRadius: '0.5rem' }}
+  src="https://mintlify-assets.b-cdn.net/bigbend.jpg"
+/>
+
+## Afbeelding
+
+### Met Markdown
+
+Met de [markdown-syntaxis](https://www.markdownguide.org/basic-syntax/#images) kun je afbeeldingen toevoegen met de volgende code:
+
+```md
+![titel](/pad/afbeelding.jpg)
+```
+
+Let op dat de bestandsgrootte van de afbeelding kleiner dan 5MB moet zijn. Is het bestand groter, host de afbeelding dan op een dienst zoals [Cloudinary](https://cloudinary.com/) of [S3](https://aws.amazon.com/s3/) en gebruik de URL in je embed.
+
+### Met embeds
+
+Wil je afbeeldingen flexibeler opmaken, gebruik dan [embeds](/writing-content/embed) om afbeeldingen op te nemen.
+
+```html
+<img height="200" src="/pad/afbeelding.jpg" />
+```
+
+## Embeds en HTML-elementen
+
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/4KzFe50RQkQ"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  style={{ width: '100%', borderRadius: '0.5rem' }}
+></iframe>
+
+<br />
+
+<Tip>
+
+Mintlify ondersteunt [HTML-tags in Markdown](https://www.markdownguide.org/basic-syntax/#html). Dat is handig als je liever HTML dan Markdown gebruikt en geeft je onbeperkte flexibiliteit bij het bouwen van documentatie.
+
+</Tip>
+
+### iFrames
+
+Laadt een andere HTML-pagina binnen het document. Meestal gebruik je dit voor het insluiten van video\'s.
+
+```html
+<iframe src="https://www.youtube.com/embed/4KzFe50RQkQ"> </iframe>
+```

--- a/nl/essentials/markdown.mdx
+++ b/nl/essentials/markdown.mdx
@@ -1,0 +1,88 @@
+---
+title: 'Markdown-syntaxis'
+description: 'Tekst, titels en opmaak in standaard Markdown'
+icon: 'text-size'
+---
+
+## Titels
+
+Gebruik je voor sectiekoppen.
+
+```md
+## Titels
+```
+
+### Subtitels
+
+Gebruik je voor subsecties.
+
+```md
+### Subtitels
+```
+
+<Tip>
+
+Elke **titel** en **subtitel** maakt een anker aan en verschijnt automatisch in de inhoudsopgave rechts.
+
+</Tip>
+
+## Tekstopmaak
+
+We ondersteunen de meeste Markdown-opmaak. Voeg simpelweg `**`, `_` of `~` rond tekst toe om deze te stylen.
+
+| Stijl         | Hoe je het schrijft    | Resultaat          |
+| ------------- | ---------------------- | ------------------ |
+| Vet           | `**vet**`              | **vet**            |
+| Cursief       | `_cursief_`            | _cursief_          |
+| Doorhalen     | `~doorhalen~`          | ~doorhalen~        |
+
+Je kunt deze stijlen combineren. Schrijf bijvoorbeeld `**_vet en cursief_**` voor **_vet en cursief_**.
+
+Gebruik HTML wanneer je superscript of subscript wilt schrijven. Voeg `<sup>` of `<sub>` rond je tekst toe.
+
+| Tekststijl   | Hoe je het schrijft           | Resultaat                 |
+| ------------ | ----------------------------- | ------------------------- |
+| Superscript  | `<sup>superscript</sup>`      | <sup>superscript</sup>    |
+| Subscript    | `<sub>subscript</sub>`        | <sub>subscript</sub>      |
+
+## Koppelingen naar pagina's
+
+Je voegt een link toe door tekst tussen `[]()` te plaatsen. Bijvoorbeeld: `[link naar Google](https://google.com)` voor een [link naar Google](https://google.com).
+
+Links naar pagina's in je documentatie moeten root-relatief zijn. Neem het volledige pad mee. Bijvoorbeeld: `[link naar tekst](/writing-content/text)` verwijst naar de pagina "Text" in de componentensectie.
+
+Relatieve links zoals `[link naar tekst](../text)` laden trager omdat we ze minder goed kunnen optimaliseren.
+
+## Blokcitaten
+
+### Enkelvoudig
+
+Maak een blokcitaat door een `>` voor een alinea te plaatsen.
+
+> Dorothy volgde haar door vele prachtige kamers in haar kasteel.
+
+```md
+> Dorothy volgde haar door vele prachtige kamers in haar kasteel.
+```
+
+### Meerdere regels
+
+> Dorothy volgde haar door vele prachtige kamers in haar kasteel.
+>
+> De heks liet haar de potten en ketels schoonmaken, de vloer vegen en het vuur van hout voorzien.
+
+```md
+> Dorothy volgde haar door vele prachtige kamers in haar kasteel.
+>
+> De heks liet haar de potten en ketels schoonmaken, de vloer vegen en het vuur van hout voorzien.
+```
+
+### LaTeX
+
+Mintlify ondersteunt [LaTeX](https://www.latex-project.org) via de Latex-component.
+
+<Latex>8 x (vk x H1 - H2) = (0,1)</Latex>
+
+```md
+<Latex>8 x (vk x H1 - H2) = (0,1)</Latex>
+```

--- a/nl/essentials/navigation.mdx
+++ b/nl/essentials/navigation.mdx
@@ -1,0 +1,66 @@
+---
+title: 'Navigatie'
+description: 'Het veld navigation in mint.json bepaalt welke pagina\'s in het navigatiemenu verschijnen'
+icon: 'map'
+---
+
+Het navigatiemenu is de lijst met links die op iedere documentatiepagina zichtbaar is.
+
+Je past `mint.json` waarschijnlijk aan telkens wanneer je een nieuwe pagina toevoegt. Pagina's verschijnen niet automatisch in de navigatie.
+
+## Navigatiesyntaxis
+
+Onze navigatiesyntaxis is recursief, wat betekent dat je geneste navigatiegroepen kunt maken. Je hoeft `.mdx` niet op te nemen in paginanamen.
+
+<CodeGroup>
+
+```json Standaardnavigatie
+"navigation": [
+    {
+        "group": "Aan de slag",
+        "pages": ["quickstart"]
+    }
+]
+```
+
+```json Geneste navigatie
+"navigation": [
+    {
+        "group": "Aan de slag",
+        "pages": [
+            "quickstart",
+            {
+                "group": "Geneste referentiepagina's",
+                "pages": ["nested-reference-page"]
+            }
+        ]
+    }
+]
+```
+
+</CodeGroup>
+
+## Mappen
+
+Plaats je MDX-bestanden simpelweg in mappen en werk de paden in `mint.json` bij.
+
+Wil je bijvoorbeeld een pagina op `https://jouwsite.com/jouw-map/jouw-pagina`, maak dan de map `jouw-map` met daarin het MDX-bestand `jouw-pagina.mdx`.
+
+<Warning>
+
+Je kunt `api` niet als mapnaam gebruiken tenzij je het in een andere map plaatst. Mintlify gebruikt Next.js, en die reserveert de bovenliggende map `api` voor interne servercalls. Een mapnaam zoals `api-reference` werkt wel.
+
+</Warning>
+
+```json Navigatie met map
+"navigation": [
+    {
+        "group": "Groepsnaam",
+        "pages": ["jouw-map/jouw-pagina"]
+    }
+]
+```
+
+## Verborgen pagina's
+
+MDX-bestanden die niet in `mint.json` staan, verschijnen niet in de zijbalk maar zijn nog steeds toegankelijk via de zoekfunctie of directe links.

--- a/nl/essentials/reusable-snippets.mdx
+++ b/nl/essentials/reusable-snippets.mdx
@@ -1,0 +1,103 @@
+---
+title: 'Herbruikbare snippets'
+description: 'Maak aangepaste snippets om content synchroon te houden'
+icon: 'recycle'
+---
+
+import SnippetIntro from '/snippets/snippet-intro.mdx';
+
+<SnippetIntro />
+
+## Een aangepaste snippet maken
+
+**Voorwaarde**: maak je snippetbestand in de map `snippets`.
+
+<Note>
+  Elke pagina in de map `snippets` wordt als snippet behandeld en niet gerenderd als zelfstandige pagina. Wil je een zelfstandige
+  pagina maken van de snippet, importeer de snippet dan in een ander bestand en gebruik hem daar als component.
+</Note>
+
+### Standaardexport
+
+1. Voeg content toe aan je snippetbestand die je op meerdere plekken wilt hergebruiken. Optioneel kun je variabelen toevoegen die
+   je later via props invult wanneer je de snippet importeert.
+
+```mdx snippets/my-snippet.mdx
+Hallo wereld! Dit is de content die ik op meerdere pagina's wil gebruiken. Mijn sleutelwoord van de dag is {word}.
+```
+
+<Warning>
+  De content die je wilt hergebruiken moet in de map `snippets` staan, anders werkt de import niet.
+</Warning>
+
+2. Importeer de snippet in het doelbestand.
+
+```mdx bestemming.mdx
+---
+title: Mijn titel
+description: Mijn beschrijving
+---
+
+import MySnippet from '/snippets/path/to/my-snippet.mdx';
+
+## Kop
+
+Lorem impsum dolor sit amet.
+
+<MySnippet word="bananen" />
+```
+
+### Herbruikbare variabelen
+
+1. Exporteer een variabele vanuit je snippetbestand:
+
+```mdx snippets/path/to/custom-variables.mdx
+export const myName = 'mijn naam';
+
+export const myObject = { fruit: 'aardbeien' };
+```
+
+2. Importeer de snippet in het doelbestand en gebruik de variabelen:
+
+```mdx bestemming.mdx
+---
+title: Mijn titel
+description: Mijn beschrijving
+---
+
+import { myName, myObject } from '/snippets/path/to/custom-variables.mdx';
+
+Hallo, mijn naam is {myName} en ik houd van {myObject.fruit}.
+```
+
+### Herbruikbare componenten
+
+1. Maak in je snippetbestand een component die props accepteert door een arrow function te exporteren.
+
+```mdx snippets/custom-component.mdx
+export const MyComponent = ({ title }) => (
+  <div>
+    <h1>{title}</h1>
+    <p>... snippetinhoud ...</p>
+  </div>
+);
+```
+
+<Warning>
+  MDX wordt niet gecompileerd binnen de body van een arrow function. Gebruik waar mogelijk HTML-syntaxis of kies voor een standaardexport als je MDX nodig hebt.
+</Warning>
+
+2. Importeer de snippet in het doelbestand en geef de props door.
+
+```mdx bestemming.mdx
+---
+title: Mijn titel
+description: Mijn beschrijving
+---
+
+import { MyComponent } from '/snippets/custom-component.mdx';
+
+Lorem ipsum dolor sit amet.
+
+<MyComponent title={'Aangepaste titel'} />
+```

--- a/nl/essentials/settings.mdx
+++ b/nl/essentials/settings.mdx
@@ -1,0 +1,258 @@
+---
+title: 'Globale instellingen'
+description: 'Mintlify geeft je volledige controle over de uitstraling van je documentatie via het bestand mint.json'
+icon: 'gear'
+---
+
+Elke Mintlify-site heeft een `mint.json`-bestand nodig met de belangrijkste configuraties. Lees hieronder meer over de [eigenschappen](#eigenschappen).
+
+## Eigenschappen
+
+<ResponseField name="name" type="string" required>
+Naam van je project. Wordt gebruikt als globale titel.
+
+Voorbeeld: `mintlify`
+
+</ResponseField>
+
+<ResponseField name="navigation" type="Navigation[]" required>
+  Een array met groepen en alle pagina's binnen die groep
+  <Expandable title="Navigatie">
+    <ResponseField name="group" type="string">
+    De naam van de groep.
+
+    Voorbeeld: `Instellingen`
+
+    </ResponseField>
+    <ResponseField name="pages" type="string[]">
+    De relatieve paden naar de markdown-bestanden die als pagina dienen.
+
+    Voorbeeld: `["customization", "page"]`
+
+    </ResponseField>
+
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="logo" type="string or object">
+  Pad naar het logo of een object met paden naar het logo voor "light" en "dark" modus
+  <Expandable title="Logo">
+    <ResponseField name="light" type="string">
+      Pad naar het logo in de lichte modus
+    </ResponseField>
+    <ResponseField name="dark" type="string">
+      Pad naar het logo in de donkere modus
+    </ResponseField>
+    <ResponseField name="href" type="string" default="/">
+      Bestemming van de link wanneer je op het logo klikt
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="favicon" type="string">
+  Pad naar het favicon-bestand
+</ResponseField>
+
+<ResponseField name="colors" type="Colors">
+  Hex-kleuren voor je globale thema
+  <Expandable title="Kleuren">
+    <ResponseField name="primary" type="string" required>
+      De primaire kleur. Wordt het vaakst gebruikt voor highlights, sectiekoppen en accenten in de lichte modus
+    </ResponseField>
+    <ResponseField name="light" type="string">
+      De primaire kleur voor de donkere modus. Wordt gebruikt voor highlights, sectiekoppen en accenten in de donkere modus
+    </ResponseField>
+    <ResponseField name="dark" type="string">
+      De primaire kleur voor belangrijke knoppen
+    </ResponseField>
+    <ResponseField name="background" type="object">
+      De achtergrondkleur voor zowel lichte als donkere modus
+      <Expandable title="Object">
+        <ResponseField name="light" type="string" required>
+          Hex-waarde van de achtergrondkleur in de lichte modus
+        </ResponseField>
+        <ResponseField name="dark" type="string" required>
+          Hex-waarde van de achtergrondkleur in de donkere modus
+        </ResponseField>
+      </Expandable>
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="topbarLinks" type="TopbarLink[]">
+  Array van `name` en `url` voor de links die je in de topbalk wilt tonen
+  <Expandable title="TopbarLink">
+    <ResponseField name="name" type="string">
+    De naam van de knop.
+
+    Voorbeeld: `Neem contact op`
+    </ResponseField>
+    <ResponseField name="url" type="string">
+    De url die wordt geopend na het klikken. Voorbeeld: `https://mintlify.com/contact`
+    </ResponseField>
+
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="topbarCtaButton" type="Call to Action">
+  <Expandable title="Topbar Call to Action">
+    <ResponseField name="type" type={'"link" or "github"'} default="link">
+    `link` toont een knop. `github` toont repo-informatie op basis van de opgegeven url, inclusief het aantal GitHub-sterren.
+    </ResponseField>
+    <ResponseField name="url" type="string">
+    Als `link`: de bestemming van de knop.
+
+    Als `github`: de link naar de repository waarvan de GitHub-informatie wordt geladen.
+    </ResponseField>
+    <ResponseField name="name" type="string">
+    Tekst in de knop. Alleen verplicht wanneer `type` `link` is.
+    </ResponseField>
+
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="versions" type="string[]">
+  Array met versienamen. Gebruik dit wanneer je verschillende documentatieversies via een keuzemenu in de navigatie wilt tonen.
+</ResponseField>
+
+<ResponseField name="anchors" type="Anchor[]">
+  Een array met anchors inclusief `icon`, `color` en `url`.
+  <Expandable title="Anchor">
+    <ResponseField name="icon" type="string">
+    Het [Font Awesome](https://fontawesome.com/search?s=brands%2Cduotone) icoon dat voor de anchor wordt gebruikt.
+
+    Voorbeeld: `comments`
+    </ResponseField>
+    <ResponseField name="name" type="string">
+    De naam van het anchor-label.
+
+    Voorbeeld: `Community`
+    </ResponseField>
+    <ResponseField name="url" type="string">
+      Het begin van de URL dat bepaalt welke pagina's onder de anchor vallen. Meestal is dit de naam van de map waarin je pagina's staan.
+    </ResponseField>
+    <ResponseField name="color" type="string">
+      De hexkleur van de achtergrond van het anchor-icoon. Dit kan ook een gradient zijn als je een object met de eigenschappen `from` en `to` meegeeft, elk met een hexkleur.
+    </ResponseField>
+    <ResponseField name="version" type="string">
+      Gebruik dit als je een anchor wilt verbergen totdat de juiste documentatieversie is geselecteerd.
+    </ResponseField>
+    <ResponseField name="isDefaultHidden" type="boolean" default="false">
+      Geef `true` door wanneer je de anchor wilt verbergen totdat iemand rechtstreeks naar pagina's binnen die anchor linkt.
+    </ResponseField>
+    <ResponseField name="iconType" default="duotone" type="string">
+      Eén van: "brands", "duotone", "light", "sharp-solid", "solid" of "thin"
+    </ResponseField>
+
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="topAnchor" type="Object">
+  Overschrijf de standaardconfiguratie voor de bovenste anchor.
+  <Expandable title="Object">
+    <ResponseField name="name" default="Documentation" type="string">
+      Naam van de bovenste anchor
+    </ResponseField>
+    <ResponseField name="icon" default="book-open" type="string">
+      Font Awesome-icoon.
+    </ResponseField>
+    <ResponseField name="iconType" default="duotone" type="string">
+      Eén van: "brands", "duotone", "light", "sharp-solid", "solid" of "thin"
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="tabs" type="Tabs[]">
+  Een array met navigatietabs.
+  <Expandable title="Tabs">
+    <ResponseField name="name" type="string">
+      De naam van het tab-label.
+    </ResponseField>
+    <ResponseField name="url" type="string">
+      Het begin van de URL dat bepaalt welke pagina's in de tab vallen. Meestal is dit de naam van de map waarin je pagina's staan.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="api" type="API">
+  Configuratie voor API-instellingen. Lees meer over API-pagina's bij [API Components](/api-playground/demo).
+  <Expandable title="API">
+    <ResponseField name="baseUrl" type="string">
+      De basis-URL voor alle API-endpoints. Als `baseUrl` een array is, kunnen gebruikers tussen meerdere basis-URL-opties wisselen.
+    </ResponseField>
+
+    <ResponseField name="auth" type="Auth">
+      <Expandable title="Auth">
+        <ResponseField name="method" type='"bearer" | "basic" | "key"'>
+          De authenticatiestrategie die in de API-playground wordt gebruikt.
+        </ResponseField>
+        <ResponseField name="name" type="string">
+        De naam van de authenticatieparameter in de API-playground.
+
+        Als de methode `basic` is, gebruik je het formaat `[usernameName]:[passwordName]`
+        </ResponseField>
+        <ResponseField name="inputPrefix" type="string">
+        De standaardwaarde die als prefix dient voor het invoerveld voor authenticatie.
+        </ResponseField>
+      </Expandable>
+    </ResponseField>
+
+    <ResponseField name="headers" type="Object[]">
+      Extra headers die standaard worden toegevoegd aan API-verzoeken.
+      <Expandable title="Header">
+        <ResponseField name="key" type="string">
+        Naam van de header
+        </ResponseField>
+        <ResponseField name="value" type="string">
+        Waarde van de header
+        </ResponseField>
+      </Expandable>
+    </ResponseField>
+
+    <ResponseField name="request" type="Object">
+      Standaardinstellingen voor de request-sectie in de API-playground.
+      <Expandable title="Request">
+        <ResponseField name="exampleType" type='"curl" | "javascript" | "python" | "php" | "go" | "ruby" | "java"'>
+          Standaardtaal voor de requestvoorbeelden.
+        </ResponseField>
+        <ResponseField name="examples" type="Object">
+          Object met codevoorbeelden per taal.
+        </ResponseField>
+      </Expandable>
+    </ResponseField>
+
+    <ResponseField name="response" type="Object">
+      Standaardinstellingen voor de response-sectie in de API-playground.
+      <Expandable title="Response">
+        <ResponseField name="exampleType" type='"json" | "xml" | "yaml"'>
+          Standaardformaat voor de responsevoorbeelden.
+        </ResponseField>
+      </Expandable>
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="customizations" type="Object">
+  Overschrijf specifieke onderdelen van de gebruikersinterface.
+  <Expandable title="Customizations">
+    <ResponseField name="background" type="Object">
+      Kleuren en afbeeldingen voor de achtergrond.
+      <Expandable title="Background">
+        <ResponseField name="light" type="string">
+          Achtergrondkleur of afbeelding in de lichte modus.
+        </ResponseField>
+        <ResponseField name="dark" type="string">
+          Achtergrondkleur of afbeelding in de donkere modus.
+        </ResponseField>
+      </Expandable>
+    </ResponseField>
+    <ResponseField name="search" type="Object">
+      Stel labels en placeholderteksten voor de zoekinterface in.
+      <Expandable title="Search">
+        <ResponseField name="placeholder" type="string">
+          Tekst die in het zoekveld verschijnt.
+        </ResponseField>
+      </Expandable>
+    </ResponseField>
+  </Expandable>
+</ResponseField>


### PR DESCRIPTION
## Summary
- update `mint.json` with locale-specific navigation groups and remove the redundant anchor so each sidebar only shows one language
- translate additional core and documentation-management guides into Dutch, including API authentication, navigation, markdown, images, code examples, reusable snippets, and settings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1dfa085388322b005012041e41c7f