### PR TITLE
Add documentation page for setup fees

### DIFF
--- a/essentials/setup-fees.mdx
+++ b/essentials/setup-fees.mdx
@@ -1,0 +1,289 @@
+---
+title: 'Setup Fees'
+description: 'Learn how to configure one-time setup fees and present them to customers.'
+---
+
+# Setup Fees
+
+Setup fees let you charge a one-time amount when a customer first purchases a product or starts a subscription. They help you
+cover onboarding, installation, or activation costs while keeping recurring prices clear and predictable.
+
+## Overview
+
+Setup fees are separate from the regular subscription price or service fee. They are typically charged once at the start of a
+customer relationship and then no longer appear on future billing cycles unless you manually add them again.
+
+## What Are Setup Fees?
+
+Setup fees can represent a wide range of one-time activities, including:
+
+- **Account setup and configuration**
+- **Installation services**
+- **Onboarding and training**
+- **Equipment deposits or security fees**
+- **Activation costs**
+- **Initial consultation fees**
+
+## How Setup Fees Work
+
+### 🔄 Subscription Products
+- The setup fee is charged **once** when the subscription is created.
+- Regular subscription billing continues on its own schedule.
+- You can decide whether to charge the setup fee immediately or with the first billing cycle.
+
+### 🛍️ Service Products
+- The setup fee is added alongside the service price.
+- Customers pay it as part of the initial order.
+- The setup fee becomes part of the total order amount.
+
+### 📦 One-time Products
+- Use setup fees when a product requires installation or preparation.
+- The fee is combined with the product price in a single transaction.
+
+## Configuration
+
+### Enabling Setup Fees
+
+1. **Navigate to Product Management**
+   - Go to **Dashboard → Products**.
+   - Select an existing product or create a new one.
+2. **Setup Fee Settings**
+   - Toggle **Enable Setup Fee** to activate the feature.
+   - Enter the setup fee amount (for example, €50.00 or €100.00).
+   - Optionally customize the setup fee name and description.
+3. **Charging Behavior for Subscriptions**
+   - **Charge Immediately**: Bill the setup fee as soon as the subscription is created.
+   - **Charge with First Cycle**: Add the setup fee to the first recurring invoice.
+
+### Setup Fee Customization
+
+You can tailor the wording that customers see so the fee makes sense for your business:
+
+- **Custom Name**: Replace "Setup Fee" with terms like "Installation Fee", "Onboarding Cost", "Deposit", or "Borg".
+- **Custom Description**: Explain what the fee covers, such as "One-time installation and configuration" or "Equipment deposit".
+- **Multi-language Support**: Custom names and descriptions follow your translation settings. If you leave them blank, the system uses
+the default "Setup Fee" text.
+
+### Default Values
+
+When no custom text is provided, customers see the default labels:
+
+- **Name**: "Setup Fee" (English) / "Setupkosten" (Dutch)
+- **Description**: "One-time setup fee for this service"
+
+## Customer Experience
+
+### 🛒 In the Shop
+- Setup fees appear on product pages with clear labeling.
+- They are automatically added when a customer adds a product to the cart.
+- Fees display separately from recurring subscription prices, with tooltips for extra context.
+
+### 💳 During Checkout
+- Setup fees show as their own line items.
+- Custom names appear everywhere you configured them.
+- The order total includes the setup fee amount, and taxes are applied when relevant.
+
+### 📧 Order Confirmation
+- Setup fees are itemized in confirmation emails.
+- They remain visible in the customer's order history.
+- Invoice PDFs include the fee with your custom terminology.
+
+## Billing Examples
+
+### Example 1: SaaS Subscription with Setup
+```
+Product: Professional Plan - €29.99/month
+Setup Fee: Onboarding Fee - €99.00
+
+Customer Charges:
+- Initial: €99.00 (setup) + €29.99 (first month) = €128.99
+- Monthly: €29.99 (recurring)
+```
+
+### Example 2: Service with Installation
+```
+Product: Website Design - €500.00
+Setup Fee: Installation Cost - €150.00
+
+Customer Charges:
+- Total: €500.00 + €150.00 = €650.00 (one-time)
+```
+
+### Example 3: Equipment Rental with Deposit
+```
+Product: Ice Skates Rental - €25.00/week
+Setup Fee: Borg - €50.00
+
+Customer Charges:
+- Initial: €50.00 (deposit) + €25.00 (first week) = €75.00
+- Weekly: €25.00 (recurring)
+```
+
+## Setup Fee Types by Product
+
+### 📱 Digital Services & SaaS
+- Account setup and configuration
+- Data migration fees
+- Custom integration costs
+- Training and onboarding sessions
+
+### 🔧 Physical Services
+- Installation and setup
+- Delivery charges
+- Equipment preparation costs
+- Site visits
+
+### 🏠 Equipment & Rentals
+- Security deposits
+- Equipment inspection
+- Delivery and pickup
+- Insurance fees
+
+### 🎓 Training & Education
+- Course materials
+- Account activation
+- Platform access setup
+- Certification fees
+
+## Payment Processing
+
+### 💰 Payment Timing
+- **Immediate**: Charge the setup fee when the order or subscription is created.
+- **With First Payment**: Combine the setup fee with the first billing cycle.
+- **Separate Transaction**: Process the setup fee as its own payment when needed.
+
+### 🔄 Subscription Integration
+- Setup fees work alongside all subscription billing cycles.
+- Trial periods remain supported—you can charge the setup fee upfront or with the first invoice.
+- Setup fees are included in subscription metrics and management tools.
+
+### 💳 Payment Methods
+- All supported payment methods can collect setup fees (card, SEPA, bank transfer, and more).
+- The same payment method handles both the setup fee and ongoing billing.
+- You can refund setup fees in full or partially, just like other charges.
+
+## Tax Handling
+
+### 🧾 Tax Calculations
+- Setup fees follow the same tax rules as the associated product.
+- Customer location determines the tax rate.
+- Invoices list taxes for setup fees as separate line items when required.
+
+### 📊 Reporting
+- Setup fee revenue is tracked separately from recurring revenue.
+- Tax reports include the taxes collected on setup fees.
+- Analytics distinguish setup revenue from ongoing subscription amounts.
+
+## Refunds and Adjustments
+
+### 💸 Setup Fee Refunds
+- Issue full or partial refunds directly from the dashboard.
+- Refunds generate a credit invoice for the customer.
+- The customer balance updates automatically, preserving a full audit trail.
+
+### ⚙️ Refund Process
+1. Open the subscription or order details.
+2. Select **Refund Setup Fee**.
+3. Choose the refund amount and provide a reason (optional).
+4. Confirm the refund so the customer receives credit.
+
+## Reporting and Analytics
+
+### 📈 Revenue Tracking
+- Monitor setup fees separately from recurring income.
+- Review monthly or yearly breakdowns.
+- Include setup fees in customer lifetime value and revenue recognition reports.
+
+### 📊 Customer Insights
+- Track conversion rates for offers that include setup fees.
+- Measure average setup fee amounts.
+- Review acquisition and churn metrics with setup fees in mind.
+
+## Best Practices
+
+### 💡 Pricing Strategy
+- Align setup fees with the actual cost of onboarding customers.
+- Research typical setup fees in your industry.
+- Use them to recover upfront costs without surprising customers.
+- Balance cost recovery with customer expectations.
+
+### 🎯 Customer Communication
+- Be transparent about what the fee covers.
+- Highlight the value customers receive for the one-time charge.
+- Use names that match your brand voice.
+- Clarify when the fee will be charged.
+
+### 🔧 Implementation Tips
+- Test different setup fee amounts or descriptions during promotions.
+- Offer limited-time discounts or waivers if it helps acquisition.
+- Adjust fees for different customer segments or product tiers.
+- Bundle setup services with premium plans to add value.
+
+## Common Use Cases
+
+### 🏢 Business Services
+- Accounting software onboarding
+- CRM implementation and data migration
+- Custom reporting dashboards
+- API or integration setup assistance
+
+### 🏠 Home Services
+- Security system installation
+- Internet or cable activation
+- Home automation configuration
+- Appliance setup and testing
+
+### 🎪 Event Services
+- Equipment delivery and setup
+- Technical rehearsal time
+- Venue preparation
+- Staff training and briefing
+
+### 📚 Educational Platforms
+- Learning management system access
+- Course materials and textbooks
+- Certification processing
+- Student account setup
+
+## Troubleshooting
+
+### ❓ Common Issues
+
+**Setup Fee Not Showing**
+- Make sure **Enable Setup Fee** is turned on.
+- Confirm the setup fee amount is greater than €0.
+- Check that the product type supports setup fees.
+
+**Incorrect Charging Behavior**
+- Verify the chosen charging behavior (immediate or first cycle).
+- Review subscription billing settings.
+- Confirm the customer has a valid payment method.
+
+**Customer Questions**
+- Provide clear descriptions explaining what the fee includes.
+- Use familiar naming to avoid confusion.
+- Offer tooltips or help text where possible.
+
+### 🔧 Resolution Steps
+1. Review the product setup fee configuration.
+2. Confirm the customer's payment details.
+3. Check the order or subscription status.
+4. Look for any in-app error messages.
+5. Test with a small transaction if necessary.
+
+## API Integration
+
+### 🔌 Setup Fee Data
+Setup fee details appear in product information, carts, orders, subscriptions, invoices, and customer portal data. This keeps your
+customer-facing tools consistent if you rely on the PayRequest API.
+
+### 📝 Webhook Events
+You receive webhook notifications when:
+- A setup fee is charged successfully
+- A setup fee payment fails
+- A setup fee is refunded
+- A setup fee configuration changes
+
+---
+
+*Setup fees provide flexible pricing options while keeping charges transparent and professional for your customers.*

--- a/mint.json
+++ b/mint.json
@@ -57,6 +57,7 @@
         "pages": [
           "essentials/payments",
           "essentials/payment-methods",
+          "essentials/setup-fees",
           "essentials/checkout-urls",
           "essentials/webhooks",
           "essentials/security"


### PR DESCRIPTION
## Summary
- add a dedicated Setup Fees guide covering configuration, customization, and customer experience details
- document billing examples, best practices, and troubleshooting tips for managing setup fees
- include the new page in the Core Concepts navigation section

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3ff9c012c83229dd144e66be404bb