### PR TITLE
Fix navigation schema error

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -42,95 +42,91 @@
     "name": "Dashboard",
     "url": "https://dashboard.payrequest.io"
   },
-  "navigation": {
-    "en": [
-      {
-        "group": "Get Started",
-        "pages": [
-          "introduction",
-          "quickstart",
-          "development"
-        ]
-      },
-      {
-        "group": "Core Concepts",
-        "pages": [
-          "essentials/payments",
-          "essentials/payment-methods",
-          "essentials/setup-fees",
-          "essentials/checkout-urls",
-          "essentials/webhooks",
-          "essentials/security"
-        ]
-      },
-      {
-        "group": "Business Workflows",
-        "pages": [
-          "essentials/invoice-templates",
-          "essentials/customer-management",
-          "essentials/payment-tracking",
-          "essentials/reporting"
-        ]
-      },
-      {
-        "group": "Invoice Management",
-        "pages": [
-          "essentials/creating-invoices",
-          "essentials/sending-invoices",
-          "essentials/tracking-payments"
-        ]
-      }
-    ],
-    "nl": [
-      {
-        "group": "Aan de slag",
-        "pages": [
-          "nl/introduction",
-          "nl/quickstart",
-          "nl/development"
-        ]
-      },
-      {
-        "group": "Belangrijkste concepten",
-        "pages": [
-          "nl/essentials/payments",
-          "nl/essentials/payment-methods",
-          "nl/essentials/checkout-urls",
-          "nl/essentials/webhooks",
-          "nl/essentials/security",
-          "nl/essentials/authentication"
-        ]
-      },
-      {
-        "group": "Zakelijke workflows",
-        "pages": [
-          "nl/essentials/invoice-templates",
-          "nl/essentials/customer-management",
-          "nl/essentials/payment-tracking",
-          "nl/essentials/reporting"
-        ]
-      },
-      {
-        "group": "Factuurbeheer",
-        "pages": [
-          "nl/essentials/creating-invoices",
-          "nl/essentials/sending-invoices",
-          "nl/essentials/tracking-payments"
-        ]
-      },
-      {
-        "group": "Documentatiebeheer",
-        "pages": [
-          "nl/essentials/navigation",
-          "nl/essentials/settings",
-          "nl/essentials/markdown",
-          "nl/essentials/code",
-          "nl/essentials/images",
-          "nl/essentials/reusable-snippets"
-        ]
-      }
-    ]
-  },
+  "navigation": [
+    {
+      "group": "Get Started",
+      "pages": [
+        "introduction",
+        "quickstart",
+        "development"
+      ]
+    },
+    {
+      "group": "Core Concepts",
+      "pages": [
+        "essentials/payments",
+        "essentials/payment-methods",
+        "essentials/setup-fees",
+        "essentials/checkout-urls",
+        "essentials/webhooks",
+        "essentials/security"
+      ]
+    },
+    {
+      "group": "Business Workflows",
+      "pages": [
+        "essentials/invoice-templates",
+        "essentials/customer-management",
+        "essentials/payment-tracking",
+        "essentials/reporting"
+      ]
+    },
+    {
+      "group": "Invoice Management",
+      "pages": [
+        "essentials/creating-invoices",
+        "essentials/sending-invoices",
+        "essentials/tracking-payments"
+      ]
+    },
+    {
+      "group": "Aan de slag",
+      "pages": [
+        "nl/introduction",
+        "nl/quickstart",
+        "nl/development"
+      ]
+    },
+    {
+      "group": "Belangrijkste concepten",
+      "pages": [
+        "nl/essentials/payments",
+        "nl/essentials/payment-methods",
+        "nl/essentials/checkout-urls",
+        "nl/essentials/webhooks",
+        "nl/essentials/security",
+        "nl/essentials/authentication"
+      ]
+    },
+    {
+      "group": "Zakelijke workflows",
+      "pages": [
+        "nl/essentials/invoice-templates",
+        "nl/essentials/customer-management",
+        "nl/essentials/payment-tracking",
+        "nl/essentials/reporting"
+      ]
+    },
+    {
+      "group": "Factuurbeheer",
+      "pages": [
+        "nl/essentials/creating-invoices",
+        "nl/essentials/sending-invoices",
+        "nl/essentials/tracking-payments"
+      ]
+    },
+    {
+      "group": "Documentatiebeheer",
+      "pages": [
+        "nl/essentials/navigation",
+        "nl/essentials/settings",
+        "nl/essentials/markdown",
+        "nl/essentials/code",
+        "nl/essentials/images",
+        "nl/essentials/reusable-snippets"
+      ]
+    }
+  ],
   "footerSocials": {
     "twitter": "https://twitter.com/payrequest_io"
   }


### PR DESCRIPTION
## Summary
- convert the navigation configuration to the array format required by the Mintlify schema
- keep the English and Dutch navigation groups available under the updated structure

## Testing
- python -m json.tool mint.json > /tmp/mint.json

------
https://chatgpt.com/codex/tasks/task_e_68d402b9e7888322b447aad4f07737d9